### PR TITLE
Add fixes for XSA-400 regression

### DIFF
--- a/SOURCES/0001-VT-d-avoid-NULL-deref-on-domain_context_mapping_one-.patch
+++ b/SOURCES/0001-VT-d-avoid-NULL-deref-on-domain_context_mapping_one-.patch
@@ -1,0 +1,165 @@
+From d64d46685c776b39d5c640a0ad2727fa0938273c Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 8 Apr 2022 15:21:33 +0200
+Subject: [PATCH] VT-d: avoid NULL deref on domain_context_mapping_one() error
+ paths
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+First there's a printk() which actually wrongly uses pdev in the first
+place: We want to log the coordinates of the (perhaps fake) device
+acted upon, which may not be pdev.
+
+Then it was quite pointless for eb19326a328d ("VT-d: prepare for per-
+device quarantine page tables (part I)") to add a domid_t parameter to
+domain_context_unmap_one(): It's only used to pass back here via
+me_wifi_quirk() -> map_me_phantom_function(). Drop the parameter again.
+
+Finally there's the invocation of domain_context_mapping_one(), which
+needs to be passed the correct domain ID. Avoid taking that path when
+pdev is NULL and the quarantine state is what would need restoring to.
+This means we can't security-support non-PCI-Express devices with RMRRs
+(if such exist in practice) any longer; note that as of trhe 1st of the
+two commits referenced below assigning them to DomU-s is unsupported
+anyway.
+
+Fixes: 8f41e481b485 ("VT-d: re-assign devices directly")
+Fixes: 14dd241aad8a ("IOMMU/x86: use per-device page tables for quarantining")
+Coverity ID: 1503784
+Reported-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+master commit: 608394b906e71587f02e6662597bc985bad33a5a
+master date: 2022-04-07 12:30:19 +0200
+---
+ xen/drivers/passthrough/vtd/extern.h |  2 +-
+ xen/drivers/passthrough/vtd/iommu.c  | 34 ++++++++++++++++------------
+ xen/drivers/passthrough/vtd/quirks.c |  2 +-
+ 3 files changed, 21 insertions(+), 17 deletions(-)
+
+diff --git a/xen/drivers/passthrough/vtd/extern.h b/xen/drivers/passthrough/vtd/extern.h
+index 897dcff9ff..fbe951b2fa 100644
+--- a/xen/drivers/passthrough/vtd/extern.h
++++ b/xen/drivers/passthrough/vtd/extern.h
+@@ -89,7 +89,7 @@ int domain_context_mapping_one(struct domain *domain, struct vtd_iommu *iommu,
+                                const struct pci_dev *pdev, domid_t domid,
+                                paddr_t pgd_maddr, unsigned int mode);
+ int domain_context_unmap_one(struct domain *domain, struct vtd_iommu *iommu,
+-                             uint8_t bus, uint8_t devfn, domid_t domid);
++                             uint8_t bus, uint8_t devfn);
+ int intel_iommu_get_reserved_device_memory(iommu_grdm_t *func, void *ctxt);
+ 
+ unsigned int io_apic_read_remap_rte(unsigned int apic, unsigned int reg);
+diff --git a/xen/drivers/passthrough/vtd/iommu.c b/xen/drivers/passthrough/vtd/iommu.c
+index 4b0d6a873c..cb3ba3e409 100644
+--- a/xen/drivers/passthrough/vtd/iommu.c
++++ b/xen/drivers/passthrough/vtd/iommu.c
+@@ -1527,7 +1527,7 @@ int domain_context_mapping_one(
+                 check_cleanup_domid_map(domain, pdev, iommu);
+             printk(XENLOG_ERR
+                    "%04x:%02x:%02x.%u: unexpected context entry %016lx_%016lx (expected %016lx_%016lx)\n",
+-                   pdev->seg, pdev->bus, PCI_SLOT(devfn), PCI_FUNC(devfn),
++                   seg, bus, PCI_SLOT(devfn), PCI_FUNC(devfn),
+                    (uint64_t)(res >> 64), (uint64_t)res,
+                    (uint64_t)(old >> 64), (uint64_t)old);
+             rc = -EILSEQ;
+@@ -1595,9 +1595,14 @@ int domain_context_mapping_one(
+ 
+     if ( rc )
+     {
+-        if ( !prev_dom )
+-            domain_context_unmap_one(domain, iommu, bus, devfn,
+-                                     DEVICE_DOMID(domain, pdev));
++        if ( !prev_dom ||
++             /*
++              * Unmapping here means DEV_TYPE_PCI devices with RMRRs (if such
++              * exist) would cause problems if such a region was actually
++              * accessed.
++              */
++             (prev_dom == dom_io && !pdev) )
++            domain_context_unmap_one(domain, iommu, bus, devfn);
+         else if ( prev_dom != domain ) /* Avoid infinite recursion. */
+             domain_context_mapping_one(prev_dom, iommu, bus, devfn, pdev,
+                                        DEVICE_DOMID(prev_dom, pdev),
+@@ -1734,7 +1739,9 @@ static int domain_context_mapping(struct domain *domain, u8 devfn,
+          * Strictly speaking if the device is the only one behind this bridge
+          * and the only one with this (secbus,0,0) tuple, it could be allowed
+          * to be re-assigned regardless of RMRR presence.  But let's deal with
+-         * that case only if it is actually found in the wild.
++         * that case only if it is actually found in the wild.  Note that
++         * dealing with this just here would still not render the operation
++         * secure.
+          */
+         else if ( prev_present && (mode & MAP_WITH_RMRR) &&
+                   domain != pdev->domain )
+@@ -1800,7 +1807,7 @@ static int domain_context_mapping(struct domain *domain, u8 devfn,
+ int domain_context_unmap_one(
+     struct domain *domain,
+     struct vtd_iommu *iommu,
+-    uint8_t bus, uint8_t devfn, domid_t domid)
++    uint8_t bus, uint8_t devfn)
+ {
+     struct context_entry *context, *context_entries;
+     u64 maddr;
+@@ -1852,7 +1859,8 @@ int domain_context_unmap_one(
+     unmap_vtd_domain_page(context_entries);
+ 
+     if ( !iommu->drhd->segment && !rc )
+-        rc = me_wifi_quirk(domain, bus, devfn, domid, 0, UNMAP_ME_PHANTOM_FUNC);
++        rc = me_wifi_quirk(domain, bus, devfn, DOMID_INVALID, 0,
++                           UNMAP_ME_PHANTOM_FUNC);
+ 
+     if ( rc && !is_hardware_domain(domain) && domain != dom_io )
+     {
+@@ -1906,8 +1914,7 @@ static const struct acpi_drhd_unit *domain_context_unmap(
+             printk(VTDPREFIX "d%d:PCIe: unmap %04x:%02x:%02x.%u\n",
+                    domain->domain_id, seg, bus,
+                    PCI_SLOT(devfn), PCI_FUNC(devfn));
+-        ret = domain_context_unmap_one(domain, iommu, bus, devfn,
+-                                       DEVICE_DOMID(domain, pdev));
++        ret = domain_context_unmap_one(domain, iommu, bus, devfn);
+         if ( !ret && devfn == pdev->devfn && ats_device(pdev, drhd) > 0 )
+             disable_ats_device(pdev);
+ 
+@@ -1917,8 +1924,7 @@ static const struct acpi_drhd_unit *domain_context_unmap(
+         if ( iommu_debug )
+             printk(VTDPREFIX "d%d:PCI: unmap %04x:%02x:%02x.%u\n",
+                    domain->domain_id, seg, bus, PCI_SLOT(devfn), PCI_FUNC(devfn));
+-        ret = domain_context_unmap_one(domain, iommu, bus, devfn,
+-                                       DEVICE_DOMID(domain, pdev));
++        ret = domain_context_unmap_one(domain, iommu, bus, devfn);
+         if ( ret )
+             break;
+ 
+@@ -1941,12 +1947,10 @@ static const struct acpi_drhd_unit *domain_context_unmap(
+             break;
+         }
+ 
+-        ret = domain_context_unmap_one(domain, iommu, tmp_bus, tmp_devfn,
+-                                       DEVICE_DOMID(domain, pdev));
++        ret = domain_context_unmap_one(domain, iommu, tmp_bus, tmp_devfn);
+         /* PCIe to PCI/PCIx bridge */
+         if ( !ret && pdev_type(seg, tmp_bus, tmp_devfn) == DEV_TYPE_PCIe2PCI_BRIDGE )
+-            ret = domain_context_unmap_one(domain, iommu, secbus, 0,
+-                                           DEVICE_DOMID(domain, pdev));
++            ret = domain_context_unmap_one(domain, iommu, secbus, 0);
+ 
+         break;
+ 
+diff --git a/xen/drivers/passthrough/vtd/quirks.c b/xen/drivers/passthrough/vtd/quirks.c
+index 4d54c21136..2b8a2bd9c6 100644
+--- a/xen/drivers/passthrough/vtd/quirks.c
++++ b/xen/drivers/passthrough/vtd/quirks.c
+@@ -363,7 +363,7 @@ static int __must_check map_me_phantom_function(struct domain *domain,
+                                         domid, pgd_maddr, mode);
+     else
+         rc = domain_context_unmap_one(domain, drhd->iommu, 0,
+-                                      PCI_DEVFN(dev, 7), domid);
++                                      PCI_DEVFN(dev, 7));
+ 
+     return rc;
+ }
+-- 
+2.25.1
+

--- a/SOURCES/0001-VT-d-avoid-infinite-recursion-on-domain_context_mapp.patch
+++ b/SOURCES/0001-VT-d-avoid-infinite-recursion-on-domain_context_mapp.patch
@@ -1,0 +1,74 @@
+From fe97133b5deef58bd1422f4d87821131c66b1d0e Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 8 Apr 2022 15:22:49 +0200
+Subject: [PATCH] VT-d: avoid infinite recursion on
+ domain_context_mapping_one() error path
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Despite the comment there infinite recursion was still possible, by
+flip-flopping between two domains. This is because prev_dom is derived
+from the DID found in the context entry, which was already updated by
+the time error recovery is invoked. Simply introduce yet another mode
+flag to prevent rolling back an in-progress roll-back of a prior
+mapping attempt.
+
+Also drop the existing recursion prevention for having been dead anyway:
+Earlier in the function we already bail when prev_dom == domain.
+
+Fixes: 8f41e481b485 ("VT-d: re-assign devices directly")
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+master commit: 99d829dba1390b98a3ca07b365713e62182ee7ca
+master date: 2022-04-07 12:31:16 +0200
+---
+ xen/drivers/passthrough/vtd/iommu.c | 7 ++++---
+ xen/drivers/passthrough/vtd/vtd.h   | 3 ++-
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/xen/drivers/passthrough/vtd/iommu.c b/xen/drivers/passthrough/vtd/iommu.c
+index cb3ba3e409..f051a55764 100644
+--- a/xen/drivers/passthrough/vtd/iommu.c
++++ b/xen/drivers/passthrough/vtd/iommu.c
+@@ -1593,7 +1593,7 @@ int domain_context_mapping_one(
+     if ( !seg && !rc )
+         rc = me_wifi_quirk(domain, bus, devfn, domid, pgd_maddr, mode);
+ 
+-    if ( rc )
++    if ( rc && !(mode & MAP_ERROR_RECOVERY) )
+     {
+         if ( !prev_dom ||
+              /*
+@@ -1603,11 +1603,12 @@ int domain_context_mapping_one(
+               */
+              (prev_dom == dom_io && !pdev) )
+             domain_context_unmap_one(domain, iommu, bus, devfn);
+-        else if ( prev_dom != domain ) /* Avoid infinite recursion. */
++        else
+             domain_context_mapping_one(prev_dom, iommu, bus, devfn, pdev,
+                                        DEVICE_DOMID(prev_dom, pdev),
+                                        DEVICE_PGTABLE(prev_dom, pdev),
+-                                       mode & MAP_WITH_RMRR);
++                                       (mode & MAP_WITH_RMRR)
++                                       | MAP_ERROR_RECOVERY);
+     }
+ 
+     if ( prev_dom )
+diff --git a/xen/drivers/passthrough/vtd/vtd.h b/xen/drivers/passthrough/vtd/vtd.h
+index e4ab242fee..cb2df76eed 100644
+--- a/xen/drivers/passthrough/vtd/vtd.h
++++ b/xen/drivers/passthrough/vtd/vtd.h
+@@ -29,7 +29,8 @@
+ #define MAP_WITH_RMRR         (1u << 0)
+ #define MAP_OWNER_DYING       (1u << 1)
+ #define MAP_SINGLE_DEVICE     (1u << 2)
+-#define UNMAP_ME_PHANTOM_FUNC (1u << 3)
++#define MAP_ERROR_RECOVERY    (1u << 3)
++#define UNMAP_ME_PHANTOM_FUNC (1u << 4)
+ 
+ /* Allow for both IOAPIC and IOSAPIC. */
+ #define IO_xAPIC_route_entry IO_APIC_route_entry
+-- 
+2.25.1
+

--- a/SOURCES/0001-VT-d-don-t-needlessly-look-up-DID.patch
+++ b/SOURCES/0001-VT-d-don-t-needlessly-look-up-DID.patch
@@ -1,0 +1,50 @@
+From a6902a65160aac72a1889a268fd5f3cebb159d8e Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 8 Apr 2022 15:20:21 +0200
+Subject: [PATCH] VT-d: don't needlessly look up DID
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+If get_iommu_domid() in domain_context_unmap_one() fails, we better
+wouldn't clear the context entry in the first place, as we're then unable
+to issue the corresponding flush. However, we have no need to look up the
+DID in the first place: What needs flushing is very specifically the DID
+that was in the context entry before our clearing of it.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+master commit: 445ab9852d69d8957467f0036098ebec75fec092
+master date: 2022-04-07 12:29:03 +0200
+---
+ xen/drivers/passthrough/vtd/iommu.c | 10 ++--------
+ 1 file changed, 2 insertions(+), 8 deletions(-)
+
+diff --git a/xen/drivers/passthrough/vtd/iommu.c b/xen/drivers/passthrough/vtd/iommu.c
+index 6571b5dde4..4b0d6a873c 100644
+--- a/xen/drivers/passthrough/vtd/iommu.c
++++ b/xen/drivers/passthrough/vtd/iommu.c
+@@ -1821,18 +1821,12 @@ int domain_context_unmap_one(
+         return 0;
+     }
+ 
++    iommu_domid = context_domain_id(*context);
++
+     context_clear_present(*context);
+     context_clear_entry(*context);
+     iommu_sync_cache(context, sizeof(struct context_entry));
+ 
+-    iommu_domid = get_iommu_did(domid, iommu, !domain->is_dying);
+-    if ( iommu_domid == -1 )
+-    {
+-        spin_unlock(&iommu->lock);
+-        unmap_vtd_domain_page(context_entries);
+-        return -EINVAL;
+-    }
+-
+     rc = iommu_flush_context_device(iommu, iommu_domid,
+                                     PCI_BDF2(bus, devfn),
+                                     DMA_CCMD_MASK_NOBIT, 0);
+-- 
+2.25.1
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -19,7 +19,7 @@ Version: 4.13.4
 # the xen_extra field can't hold more than 16 chars
 # so instead of using %%release to define XEN_VENDORVERSION
 # we create a base_release macro, that doesn't contain the dist suffix
-%define base_release 9.21.1
+%define base_release 9.21.2
 Release: %{base_release}%{?dist}
 License: GPLv2 and LGPLv2+ and BSD
 URL:     http://www.xenproject.org
@@ -264,6 +264,11 @@ Patch231: xen-introspection-pause.patch
 Patch232: xen-always-enable-altp2m-external-mode.patch
 Patch233: 0001-x86-add-XEN_SYSCTL_spec_ctrl.patch
 Patch234: 0002-x86-add-xen-spec-ctrl-utility.patch
+
+# XCP-ng patches
+Patch1000: 0001-VT-d-don-t-needlessly-look-up-DID.patch
+Patch1001: 0001-VT-d-avoid-NULL-deref-on-domain_context_mapping_one-.patch
+Patch1002: 0001-VT-d-avoid-infinite-recursion-on-domain_context_mapp.patch
 
 Provides: gitsha(https://code.citrite.net/rest/archive/latest/projects/XSU/repos/xen/archive?at=RELEASE-4.13.4&prefix=xen-4.13.4&format=tar.gz#/xen-4.13.4.tar.gz) = 6e2fc128eb1a7d8ff8c36123a0a03e4e60a4a44c
 Provides: gitsha(ssh://git@code.citrite.net/xs/xen.pg.git) = 63a9ddfe30f43e81901091445e9d969c9f06dce1
@@ -1101,13 +1106,13 @@ touch %{_rundir}/reboot-required.d/%{name}/%{version}-%{base_release}
 
 %{?_cov_results_package}
 %changelog
-* Tue Apr 05 2022 Samuel Verschelde <stormi-xcp@ylix.fr> - 4.13.4-9.21.1
+* Tue Apr 05 2022 Samuel Verschelde <stormi-xcp@ylix.fr> - 4.13.4-9.21.2
 - Security update, synced from hotfix XS82ECU1007
 - Related to XSAs 397, 399 and 400
 - See http://xenbits.xen.org/xsa/
+- Additional patches added from upstream xen to fix fallouts of XSA-400 patches
 - Reboot required
 
-%changelog
 * Wed Mar 09 2022 Samuel Verschelde <stormi-xcp@ylix.fr> - 4.13.4-9.20.1
 - Security update, synced from hotfix XS82ECU1006
 - Related to XSA 398


### PR DESCRIPTION
This commit adds the patches from the following commits:
- a6902a6
- d64d466
- fe97133
These commits fix the regression introduced by XSA-400.