### PR TITLE
Apply a patch to the patch for XSA-433

### DIFF
--- a/SOURCES/xsa433.patch
+++ b/SOURCES/xsa433.patch
@@ -39,8 +39,8 @@ index 959790575ad2..0f47ec4ab7c0 100644
 +void amd_check_zenbleed(void)
 +{
 +	const struct cpu_signature *sig = &this_cpu(cpu_sig);
-+	unsigned int good_rev, chickenbit = (1 << 9);
-+	uint64_t val, old_val;
++	unsigned int good_rev;
++	uint64_t val, old_val, chickenbit = (1 << 9);
 +
 +	/*
 +	 * If we're virtualised, we can't do family/model checks safely, and

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -34,7 +34,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.13.5
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.13.5.tar.gz
@@ -1187,6 +1187,9 @@ touch %{_rundir}/reboot-required.d/%{name}/%{version}-%{hv_rel}
 %{?_cov_results_package}
 
 %changelog
+* Thu Aug 03 2023 Gael Duperrey <gduperrey@vates.fr> - 4.13.5-9.34.2
+- Apply a patch for the XSA-433 patch
+
 * Mon Jul 24 2023 Gael Duperrey <gduperrey@vates.fr> - 4.13.5-9.34.1
 - Synced from hotfix XS82ECU1041 
 - *** Upstream changelog ***


### PR DESCRIPTION
The patch provided with earlier versions was buggy.  It unintentionally disable more bits than expected in the control register.  The contents of this register is not generally known, so the effects on the system are unknown.

We applied the patch on the first one.