### PR TITLE
xenguest: activate nested virt when requested

### DIFF
--- a/SOURCES/0001-xenguest-activate-nested-virt-when-requested.patch
+++ b/SOURCES/0001-xenguest-activate-nested-virt-when-requested.patch
@@ -1,0 +1,28 @@
+From d92a9857aa76b2206d78c5e70362c8e9eec2e1e9 Mon Sep 17 00:00:00 2001
+From: Yann Dirson <yann.dirson@vates.tech>
+Date: Mon, 3 Feb 2025 17:06:19 +0100
+Subject: [PATCH] xenguest: activate nested virt when requested
+
+---
+ tools/xenguest/xenguest_stubs.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/tools/xenguest/xenguest_stubs.c b/tools/xenguest/xenguest_stubs.c
+index 4eda3ee..20dc7ce 100644
+--- a/tools/xenguest/xenguest_stubs.c
++++ b/tools/xenguest/xenguest_stubs.c
+@@ -304,6 +304,11 @@ static int construct_cpuid_policy(const struct flags *f, bool hvm, bool restore)
+     if ( !f->pae )
+         clear_bit(X86_FEATURE_PAE, featureset);
+ 
++    if ( f->nested_virt ) {
++        set_bit(X86_FEATURE_VMX, featureset);
++        set_bit(X86_FEATURE_SVM, featureset);
++    }
++
+     /*
+      * Optionally advertise ITSC, given hardware support an a non-migratealbe
+      * domain.
+-- 
+2.39.5
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -33,7 +33,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.5
-Release: %{?xsrel}%{?dist}
+Release: %{?xsrel}.1%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.5.tar.gz
@@ -227,6 +227,8 @@ Patch182: allow-rombios-pci-config-on-any-host-bridge.patch
 Patch183: gvt-g-hvmloader+rombios.patch
 Patch184: xen-spec-ctrl-utility.patch
 Patch185: vtpm-ppi-acpi-dsm.patch
+
+Patch1000: 0001-xenguest-activate-nested-virt-when-requested.patch
 
 ExclusiveArch: x86_64
 
@@ -1072,6 +1074,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Mon Feb  6 2025 Yann Dirson <yann.dirson@vates.tech> - 4.17.5-4.1
+- xenguest: activate nested virt when requested
+
 * Tue Nov  5 2024 Andrew Cooper <andrew.cooper3@citrix.com> - 4.17.5-4
 - Fixes for
   - XSA-463 CVE-2024-45818


### PR DESCRIPTION
To test, set this XAPI VM param:
```
xe vm-param-set platform:nested-virt=true
```
