### PR TITLE
Use ERMS variant for memcpy

### DIFF
--- a/SOURCES/memcpy-erms.patch
+++ b/SOURCES/memcpy-erms.patch
@@ -1,0 +1,43 @@
+From b7e78f7b944c4e95fb0eaf76ba5ffa6ed653facc Mon Sep 17 00:00:00 2001
+Message-ID: <b7e78f7b944c4e95fb0eaf76ba5ffa6ed653facc.1744029730.git.teddy.astie@vates.tech>
+From: Teddy Astie <teddy.astie@vates.tech>
+Date: Mon, 7 Apr 2025 14:42:04 +0200
+Subject: [PATCH] x86: Replace memcpy implementation with ERMS variant
+
+Xen uses rep movsq+b for copying memory, according Intel Optimization Reference Manual,
+this is not the most efficient way of doing it, at least for CPUs exposing the ERMS flag
+(which concern the vast majority of relevant Intel CPUs and Zen3+ AMD CPUs).
+
+This patch replace the memcpy implementation with a plain rep movsb which is expected to
+perform better on most CPUs.
+
+Signed-off-by: Teddy Astie <teddy.astie@vates.tech>
+---
+ xen/arch/x86/string.c | 11 +----------
+ 1 file changed, 1 insertion(+), 10 deletions(-)
+
+diff --git a/xen/arch/x86/string.c b/xen/arch/x86/string.c
+index bda24b14ac..154d1fda3b 100644
+--- a/xen/arch/x86/string.c
++++ b/xen/arch/x86/string.c
+@@ -9,16 +9,7 @@
+ 
+ void *(memcpy)(void *dest, const void *src, size_t n)
+ {
+-    long d0, d1, d2;
+-
+-    asm volatile (
+-        "   rep ; movs"__OS" ; "
+-        "   mov %k4,%k3      ; "
+-        "   rep ; movsb        "
+-        : "=&c" (d0), "=&D" (d1), "=&S" (d2)
+-        : "0" (n/BYTES_PER_LONG), "r" (n%BYTES_PER_LONG), "1" (dest), "2" (src)
+-        : "memory" );
+-
++    asm volatile ("rep movsb" :: "c"(n), "D"(dest), "S"(src) : "memory");
+     return dest;
+ }
+ 
+-- 
+2.47.2
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -33,7 +33,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.5
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.1.0.erms.1%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.5.tar.gz
@@ -240,6 +240,7 @@ Patch194: vtpm-ppi-acpi-dsm.patch
 # XCP-ng patches
 Patch1000: 0001-xenguest-activate-nested-virt-when-requested.patch
 Patch1001: xsa467.patch
+Patch1002: memcpy-erms.patch
 
 ExclusiveArch: x86_64
 
@@ -1085,6 +1086,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Mon Apr  7 2025 Teddy Astie <teddy.astie@vates.tech> - 4.17.5-6.1.0.erms.1
+ - Use ERMS variant for memcpy
+
 * Wed Mar 05 2025 Thierry Escande <thierry.escande@vates.tech> - 4.17.5-6.1
 - Sync with 4.17.5-6
 - *** Upstream changelog ***


### PR DESCRIPTION
Xen uses by default rep movsq+b for memcpy, which is not optimal according to Intel Architectures Optimization Reference Manual.
> Using Enhanced REP MOVSB and STOSB always delivers better performance than using REP MOVSD+B.

ERMS flag is exposed on the vast majority of Intel CPUs that support XCP-ng (Intel EPT), it is also exposed on AMD CPUs starting with Zen 3.

This change replace the Xen's memcpy implementation used by Xen with `rep movsb`.

This change needs some evaluation before putting it in production :
- needs some general testing
- some benchmarks on multiple CPUs (especially regarding PV driver performance) on Intel and AMD