### PR TITLE
Backport dd05d265b8ab "x86/intel: Fix PERF_GLOBAL fixup when virtualised"

### DIFF
--- a/SOURCES/xen-4.17.5-x86-intel-Fix-PERF_GLOBAL-fixup-when-virtualised.patch
+++ b/SOURCES/xen-4.17.5-x86-intel-Fix-PERF_GLOBAL-fixup-when-virtualised.patch
@@ -1,0 +1,115 @@
+From dd05d265b8abda4cc7206b29cd71b77fb46658bf Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Tue, 21 Jan 2025 16:56:26 +0000
+Subject: [PATCH] x86/intel: Fix PERF_GLOBAL fixup when virtualised
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf8
+Content-Transfer-Encoding: 8bit
+
+Logic using performance counters needs to look at
+MSR_MISC_ENABLE.PERF_AVAILABLE before touching any other resources.
+
+When virtualised under ESX, Xen dies with a #GP fault trying to read
+MSR_CORE_PERF_GLOBAL_CTRL.
+
+Factor this logic out into a separate function (it's already too squashed to
+the RHS), and insert a check of MSR_MISC_ENABLE.PERF_AVAILABLE.
+
+This also avoids setting X86_FEATURE_ARCH_PERFMON if MSR_MISC_ENABLE says that
+PERF is unavailable, although oprofile (the only consumer of this flag)
+cross-checks too.
+
+Fixes: 6bdb965178bb ("x86/intel: ensure Global Performance Counter Control is setup correctly")
+Reported-by: Jonathan Katz <jonathan.katz@aptar.com>
+Link: https://xcp-ng.org/forum/topic/10286/nesting-xcp-ng-on-esx-8
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Roger Pau MonnÃ© <roger.pau@citrix.com>
+Tested-by: Jonathan Katz <jonathan.katz@aptar.com>
+---
+ xen/arch/x86/cpu/intel.c | 64 +++++++++++++++++++++++-----------------
+ 1 file changed, 37 insertions(+), 27 deletions(-)
+
+diff --git a/xen/arch/x86/cpu/intel.c b/xen/arch/x86/cpu/intel.c
+index 6a7347968b..6a680ba38d 100644
+--- a/xen/arch/x86/cpu/intel.c
++++ b/xen/arch/x86/cpu/intel.c
+@@ -535,39 +535,49 @@ static void intel_log_freq(const struct cpuinfo_x86 *c)
+     printk("%u MHz\n", (factor * max_ratio + 50) / 100);
+ }
+ 
++static void init_intel_perf(struct cpuinfo_x86 *c)
++{
++    uint64_t val;
++    unsigned int eax, ver, nr_cnt;
++
++    if ( c->cpuid_level <= 9 ||
++         ({  rdmsrl(MSR_IA32_MISC_ENABLE, val);
++             !(val & MSR_IA32_MISC_ENABLE_PERF_AVAIL); }) )
++        return;
++
++    eax = cpuid_eax(10);
++    ver = eax & 0xff;
++    nr_cnt = (eax >> 8) & 0xff;
++
++    if ( ver && nr_cnt > 1 && nr_cnt <= 32 )
++    {
++        unsigned int cnt_mask = (1UL << nr_cnt) - 1;
++
++        /*
++         * On (some?) Sapphire/Emerald Rapids platforms each package-BSP
++         * starts with all the enable bits for the general-purpose PMCs
++         * cleared.  Adjust so counters can be enabled from EVNTSEL.
++         */
++        rdmsrl(MSR_CORE_PERF_GLOBAL_CTRL, val);
++
++        if ( (val & cnt_mask) != cnt_mask )
++        {
++            printk("FIRMWARE BUG: CPU%u invalid PERF_GLOBAL_CTRL: %#"PRIx64" adjusting to %#"PRIx64"\n",
++                   smp_processor_id(), val, val | cnt_mask);
++            wrmsrl(MSR_CORE_PERF_GLOBAL_CTRL, val | cnt_mask);
++        }
++
++        __set_bit(X86_FEATURE_ARCH_PERFMON, c->x86_capability);
++    }
++}
++
+ static void cf_check init_intel(struct cpuinfo_x86 *c)
+ {
+ 	/* Detect the extended topology information if available */
+ 	detect_extended_topology(c);
+ 
+ 	init_intel_cacheinfo(c);
+-	if (c->cpuid_level > 9) {
+-		unsigned eax = cpuid_eax(10);
+-		unsigned int cnt = (eax >> 8) & 0xff;
+-
+-		/* Check for version and the number of counters */
+-		if ((eax & 0xff) && (cnt > 1) && (cnt <= 32)) {
+-			uint64_t global_ctrl;
+-			unsigned int cnt_mask = (1UL << cnt) - 1;
+-
+-			/*
+-			 * On (some?) Sapphire/Emerald Rapids platforms each
+-			 * package-BSP starts with all the enable bits for the
+-			 * general-purpose PMCs cleared.  Adjust so counters
+-			 * can be enabled from EVNTSEL.
+-			 */
+-			rdmsrl(MSR_CORE_PERF_GLOBAL_CTRL, global_ctrl);
+-			if ((global_ctrl & cnt_mask) != cnt_mask) {
+-				printk("CPU%u: invalid PERF_GLOBAL_CTRL: %#"
+-				       PRIx64 " adjusting to %#" PRIx64 "\n",
+-				       smp_processor_id(), global_ctrl,
+-				       global_ctrl | cnt_mask);
+-				wrmsrl(MSR_CORE_PERF_GLOBAL_CTRL,
+-				       global_ctrl | cnt_mask);
+-			}
+-			__set_bit(X86_FEATURE_ARCH_PERFMON, c->x86_capability);
+-		}
+-	}
++	init_intel_perf(c);
+ 
+ 	if ( !cpu_has(c, X86_FEATURE_XTOPOLOGY) )
+ 	{
+-- 
+2.39.5
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -33,7 +33,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.5
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.5.tar.gz
@@ -255,6 +255,7 @@ Patch206: vtpm-ppi-acpi-dsm.patch
 # XCP-ng patches
 Patch1000: 0001-xenguest-activate-nested-virt-when-requested.patch
 Patch1001: xsa467.patch
+Patch1002: xen-4.17.5-x86-intel-Fix-PERF_GLOBAL-fixup-when-virtualised.patch
 
 ExclusiveArch: x86_64
 
@@ -1100,6 +1101,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Mon May 05 2025 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.17.5-9.3
+- Backport dd05d265b8ab "x86/intel: Fix PERF_GLOBAL fixup when virtualised"
+
 * Tue Apr 29 2025 Yann Dirson <yann.dirson@vates.tech> - 4.17.5-9.2
 - Rebuild against ncurses 6.4-6.20240309 to pull abi5 (compat) libs
 


### PR DESCRIPTION
Patch taken from Xen staging.

Link: https://xenbits.xen.org/gitweb/?p=xen.git;a=patch;h=dd05d265b8abda4cc7206b29cd71b77fb46658bf
Link: https://github.com/xcp-ng/xcp/issues/697