### PR TITLE
Rebase on 4.17.5-13, fixes XSA-469

### DIFF
--- a/SOURCES/backport-4aae4452efee.patch
+++ b/SOURCES/backport-4aae4452efee.patch
@@ -1,0 +1,125 @@
+From 4aae4452efeee3d3bba092b875e37d1e7c8f6db9 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Thu, 17 Apr 2025 12:35:28 +0200
+Subject: x86/intel: workaround several MONITOR/MWAIT errata
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+There are several errata on Intel regarding the usage of the MONITOR/MWAIT
+instructions, all having in common that stores to the monitored region
+might not wake up the CPU.
+
+Fix them by forcing the sending of an IPI for the affected models.
+
+The Ice Lake issue has been reproduced internally on XenServer hardware,
+and the fix does seem to prevent it.  The symptom was APs getting stuck in
+the idle loop immediately after bring up, which in turn prevented the BSP
+from making progress.  This would happen before the watchdog was
+initialized, and hence the whole system would get stuck.
+
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Acked-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+diff --git a/xen/arch/x86/acpi/cpu_idle.c b/xen/arch/x86/acpi/cpu_idle.c
+index fca48b2a4fdc..2ce9f1cdda8a 100644
+--- a/xen/arch/x86/acpi/cpu_idle.c
++++ b/xen/arch/x86/acpi/cpu_idle.c
+@@ -453,8 +453,14 @@ void cpuidle_wakeup_mwait(cpumask_t *mask)
+     cpumask_andnot(mask, mask, &target);
+ }
+ 
++/* Force sending of a wakeup IPI regardless of mwait usage. */
++bool __ro_after_init force_mwait_ipi_wakeup;
++
+ bool arch_skip_send_event_check(unsigned int cpu)
+ {
++    if ( force_mwait_ipi_wakeup )
++        return false;
++
+     /*
+      * This relies on softirq_pending() and mwait_wakeup() to access data
+      * on the same cache line.
+diff --git a/xen/arch/x86/cpu/intel.c b/xen/arch/x86/cpu/intel.c
+index 673b80afef57..ac21bbf21f08 100644
+--- a/xen/arch/x86/cpu/intel.c
++++ b/xen/arch/x86/cpu/intel.c
+@@ -7,6 +7,7 @@
+ #include <asm/intel-family.h>
+ #include <asm/processor.h>
+ #include <asm/msr.h>
++#include <asm/mwait.h>
+ #include <asm/uaccess.h>
+ #include <asm/mpspec.h>
+ #include <asm/apic.h>
+@@ -358,7 +359,6 @@ static void probe_c3_errata(const struct cpuinfo_x86 *c)
+         INTEL_FAM6_MODEL(0x25),
+         { }
+     };
+-#undef INTEL_FAM6_MODEL
+ 
+     /* Serialized by the AP bringup code. */
+     if ( max_cstate > 1 && (c->apicid & (c->x86_num_siblings - 1)) &&
+@@ -370,6 +370,38 @@ static void probe_c3_errata(const struct cpuinfo_x86 *c)
+     }
+ }
+ 
++/*
++ * APL30: One use of the MONITOR/MWAIT instruction pair is to allow a logical
++ * processor to wait in a sleep state until a store to the armed address range
++ * occurs. Due to this erratum, stores to the armed address range may not
++ * trigger MWAIT to resume execution.
++ *
++ * ICX143: Under complex microarchitectural conditions, a monitor that is armed
++ * with the MWAIT instruction may not be triggered, leading to a processor
++ * hang.
++ *
++ * LNL030: Problem P-cores may not exit power state Core C6 on monitor hit.
++ *
++ * Force the sending of an IPI in those cases.
++ */
++static void __init probe_mwait_errata(void)
++{
++    static const struct x86_cpu_id __initconst models[] = {
++        INTEL_FAM6_MODEL(INTEL_FAM6_ATOM_GOLDMONT), /* APL30  */
++        INTEL_FAM6_MODEL(INTEL_FAM6_ICELAKE_X),     /* ICX143 */
++        INTEL_FAM6_MODEL(INTEL_FAM6_LUNARLAKE_M),   /* LNL030 */
++        { }
++    };
++#undef INTEL_FAM6_MODEL
++
++    if ( boot_cpu_has(X86_FEATURE_MONITOR) && x86_match_cpu(models) )
++    {
++        printk(XENLOG_WARNING
++               "Forcing IPI MWAIT wakeup due to CPU erratum\n");
++        force_mwait_ipi_wakeup = true;
++    }
++}
++
+ /*
+  * P4 Xeon errata 037 workaround.
+  * Hardware prefetcher may cause stale data to be loaded into the cache.
+@@ -396,6 +428,8 @@ static void Intel_errata_workarounds(struct cpuinfo_x86 *c)
+ 		__set_bit(X86_FEATURE_CLFLUSH_MONITOR, c->x86_capability);
+ 
+ 	probe_c3_errata(c);
++	if (system_state < SYS_STATE_smp_boot)
++		probe_mwait_errata();
+ }
+ 
+ 
+diff --git a/xen/arch/x86/include/asm/mwait.h b/xen/arch/x86/include/asm/mwait.h
+index f377d9fdcad4..97bf361505f0 100644
+--- a/xen/arch/x86/include/asm/mwait.h
++++ b/xen/arch/x86/include/asm/mwait.h
+@@ -13,6 +13,9 @@
+ 
+ #define MWAIT_ECX_INTERRUPT_BREAK	0x1
+ 
++/* Force sending of a wakeup IPI regardless of mwait usage. */
++extern bool force_mwait_ipi_wakeup;
++
+ void mwait_idle_with_hints(unsigned int eax, unsigned int ecx);
+ bool mwait_pc10_supported(void);
+ 

--- a/SOURCES/backport-8c12e47a5d3b.patch
+++ b/SOURCES/backport-8c12e47a5d3b.patch
@@ -1,0 +1,27 @@
+From 8c12e47a5d3b8ef7484b4a6d04b73bd6c61a82cf Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Tue, 18 Feb 2025 23:01:11 +0000
+Subject: xen/domain: Annotate struct domain as page aligned
+
+struct domain is always a page aligned allocation.  Update it's type to
+reflect this, so we can safely reuse the lower bits in the pointer for
+auxiliary information.
+
+No functional change.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Stefano Stabellini <sstabellini@kernel.org>
+
+diff --git a/xen/include/xen/sched.h b/xen/include/xen/sched.h
+index 072e4846aae4..4b9077eebc9f 100644
+--- a/xen/include/xen/sched.h
++++ b/xen/include/xen/sched.h
+@@ -602,7 +602,7 @@ struct domain
+ 
+     /* Holding CDF_* constant. Internal flags for domain creation. */
+     unsigned int cdf;
+-};
++} __aligned(PAGE_SIZE);
+ 
+ static inline struct page_list_head *page_to_list(
+     struct domain *d, const struct page_info *pg)

--- a/SOURCES/backport-9a474fcceccf.patch
+++ b/SOURCES/backport-9a474fcceccf.patch
@@ -1,0 +1,68 @@
+From 9a474fcceccf0add2ff7f6c7d4ebd24159edf544 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Fri, 7 Mar 2025 14:24:42 +0000
+Subject: xen/watchdog: Identify which domain watchdog fired
+
+When a watchdog fires, the domain is crashed and can't dump any state.
+
+Xen allows a domain to have two separate watchdogs.  Therefore, for a
+domain running multiple watchdogs (e.g. one based around network, one
+for disk), it is important for diagnostics to know which watchdog
+fired.
+
+As the printk() is in a timer callback, this is a bit awkward to
+arrange, but there are 12 spare bits in the bottom of the domain
+pointer owing to its alignment.
+
+Reuse these bits to encode the watchdog id too, so the one which fired
+is identified when the domain is crashed.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Juergen Gross <jgross@suse.com>
+
+diff --git a/xen/common/sched/core.c b/xen/common/sched/core.c
+index 8c6c26b562f6..78c5917788fe 100644
+--- a/xen/common/sched/core.c
++++ b/xen/common/sched/core.c
+@@ -1536,12 +1536,19 @@ long vcpu_yield(void)
+ 
+ static void cf_check domain_watchdog_timeout(void *data)
+ {
+-    struct domain *d = data;
++    /*
++     * The data parameter encodes the watchdog id in the low bits of
++     * the domain pointer.
++     */
++    struct domain *d = _p((unsigned long)data & PAGE_MASK);
++    unsigned int id = (unsigned long)data & ~PAGE_MASK;
++
++    BUILD_BUG_ON(alignof(*d) < PAGE_SIZE);
+ 
+     if ( d->is_shutting_down || d->is_dying )
+         return;
+ 
+-    printk("Watchdog timer fired for domain %u\n", d->domain_id);
++    printk("Watchdog timer %u fired for %pd\n", id, d);
+     domain_shutdown(d, SHUTDOWN_watchdog);
+ }
+ 
+@@ -1595,7 +1602,17 @@ void watchdog_domain_init(struct domain *d)
+     d->watchdog_inuse_map = 0;
+ 
+     for ( i = 0; i < NR_DOMAIN_WATCHDOG_TIMERS; i++ )
+-        init_timer(&d->watchdog_timer[i], domain_watchdog_timeout, d, 0);
++    {
++        void *data = d;
++
++        BUILD_BUG_ON(NR_DOMAIN_WATCHDOG_TIMERS > alignof(*d));
++
++        /*
++         * For the timer callback parameter, encode the watchdog id in
++         * the low bits of the domain pointer.
++         */
++        init_timer(&d->watchdog_timer[i], domain_watchdog_timeout, data + i, 0);
++    }
+ }
+ 
+ void watchdog_domain_destroy(struct domain *d)

--- a/SOURCES/backport-b28b590d4a23.patch
+++ b/SOURCES/backport-b28b590d4a23.patch
@@ -1,0 +1,81 @@
+From b28b590d4a23894672f1dd7fb98cdf9926ecb282 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Thu, 28 Nov 2024 00:47:36 +0000
+Subject: x86/vlapic: Fix handling of writes to APIC_ESR
+
+Xen currently presents APIC_ESR to guests as a simple read/write register.
+
+This is incorrect.  The SDM states:
+
+  The ESR is a write/read register. Before attempt to read from the ESR,
+  software should first write to it. (The value written does not affect the
+  values read subsequently; only zero may be written in x2APIC mode.) This
+  write clears any previously logged errors and updates the ESR with any
+  errors detected since the last write to the ESR.
+
+Introduce a new pending_esr field in hvm_hw_lapic.
+
+Update vlapic_error() to accumulate errors here, and extend vlapic_reg_write()
+to discard the written value and transfer pending_esr into APIC_ESR.  Reads
+are still as before.
+
+Importantly, this means that guests no longer destroys the ESR value it's
+looking for in the LVTERR handler when following the SDM instructions.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+diff --git a/xen/arch/x86/hvm/vlapic.c b/xen/arch/x86/hvm/vlapic.c
+index 91fc45716514..d7dd430bd1d0 100644
+--- a/xen/arch/x86/hvm/vlapic.c
++++ b/xen/arch/x86/hvm/vlapic.c
+@@ -108,7 +108,7 @@ static void vlapic_error(struct vlapic *vlapic, unsigned int errmask)
+     uint32_t esr;
+ 
+     spin_lock_irqsave(&vlapic->esr_lock, flags);
+-    esr = vlapic_get_reg(vlapic, APIC_ESR);
++    esr = vlapic->hw.pending_esr;
+     if ( (esr & errmask) != errmask )
+     {
+         uint32_t lvterr = vlapic_get_reg(vlapic, APIC_LVTERR);
+@@ -127,7 +127,7 @@ static void vlapic_error(struct vlapic *vlapic, unsigned int errmask)
+                  errmask |= APIC_ESR_RECVILL;
+         }
+ 
+-        vlapic_set_reg(vlapic, APIC_ESR, esr | errmask);
++        vlapic->hw.pending_esr |= errmask;
+ 
+         if ( inj )
+             vlapic_set_irq(vlapic, lvterr & APIC_VECTOR_MASK, 0);
+@@ -802,6 +802,19 @@ void vlapic_reg_write(struct vcpu *v, unsigned int reg, uint32_t val)
+         vlapic_set_reg(vlapic, APIC_ID, val);
+         break;
+ 
++    case APIC_ESR:
++    {
++        unsigned long flags;
++
++        spin_lock_irqsave(&vlapic->esr_lock, flags);
++        val = vlapic->hw.pending_esr;
++        vlapic->hw.pending_esr = 0;
++        spin_unlock_irqrestore(&vlapic->esr_lock, flags);
++
++        vlapic_set_reg(vlapic, APIC_ESR, val);
++        break;
++    }
++
+     case APIC_TASKPRI:
+         vlapic_set_reg(vlapic, APIC_TASKPRI, val & 0xff);
+         break;
+diff --git a/xen/include/public/arch-x86/hvm/save.h b/xen/include/public/arch-x86/hvm/save.h
+index 7ecacadde165..9c4bfc7ebdac 100644
+--- a/xen/include/public/arch-x86/hvm/save.h
++++ b/xen/include/public/arch-x86/hvm/save.h
+@@ -394,6 +394,7 @@ struct hvm_hw_lapic {
+     uint32_t             disabled; /* VLAPIC_xx_DISABLED */
+     uint32_t             timer_divisor;
+     uint64_t             tdt_msr;
++    uint32_t             pending_esr;
+ };
+ 
+ DECLARE_HVM_SAVE_TYPE(LAPIC, 5, struct hvm_hw_lapic);

--- a/SOURCES/backport-c989ff614f6b.patch
+++ b/SOURCES/backport-c989ff614f6b.patch
@@ -1,0 +1,47 @@
+From c989ff614f6bad48b3bd4b32694f711b31c7b2d6 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Mon, 17 Feb 2025 15:51:51 +0000
+Subject: x86/svm: Separate STI and VMRUN instructions in svm_asm_do_resume()
+
+There is a corner case in the VMRUN instruction where its INTR_SHADOW state
+leaks into guest state if a VMExit occurs before the VMRUN is complete.  An
+example of this could be taking #NPF due to event injection.
+
+Xen can safely execute STI anywhere between CLGI and VMRUN, as CLGI blocks
+external interrupts too.  However, an exception (while fatal) will appear to
+be in an irqs-on region (as GIF isn't considered), so position the STI after
+the speculation actions but prior to the GPR pops.
+
+Link: https://lore.kernel.org/all/CADH9ctBs1YPmE4aCfGPNBwA10cA8RuAk2gO7542DjMZgs4uzJQ@mail.gmail.com/
+Fixes: 66b245d9eaeb ("SVM: limit GIF=0 region")
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Release-Acked-by: Oleksii Kurochko <oleksii.kurochko@gmail.com>
+
+diff --git a/xen/arch/x86/hvm/svm/entry.S b/xen/arch/x86/hvm/svm/entry.S
+index 6fd9652c04a1..91edb3345938 100644
+--- a/xen/arch/x86/hvm/svm/entry.S
++++ b/xen/arch/x86/hvm/svm/entry.S
+@@ -74,6 +74,14 @@ __UNLIKELY_END(nsvm_hap)
+         ALTERNATIVE "", svm_vmentry_spec_ctrl, X86_FEATURE_SC_MSR_HVM
+         ALTERNATIVE "", DO_SPEC_CTRL_DIV, X86_FEATURE_SC_DIV
+ 
++        /*
++         * Set EFLAGS.IF after CLGI covers us from real interrupts, but not
++         * immediately prior to VMRUN.  The VMRUN instruction leaks it's
++         * INTR_SHADOW into guest state if a VMExit occurs before VMRUN
++         * completes (e.g. taking #NPF during event injecting.)
++         */
++        sti
++
+         pop  %r15
+         pop  %r14
+         pop  %r13
+@@ -91,7 +99,6 @@ __UNLIKELY_END(nsvm_hap)
+         pop  %rsi
+         pop  %rdi
+ 
+-        sti
+         vmrun
+ 
+         SAVE_ALL

--- a/SOURCES/backport-d444763f8ca5.patch
+++ b/SOURCES/backport-d444763f8ca5.patch
@@ -1,0 +1,103 @@
+From d444763f8ca556d0a67a4b933be303d346baef02 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Wed, 5 Mar 2025 11:53:20 +0100
+Subject: xen: remove -N from the linker command line
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It's unclear why -N is being used in the first place.  It was added by
+commit 4676bbf96dc8 back in 2002 without any justification.
+
+When building a PE image it's actually detrimental to forcefully set the
+.text section as writable.  The GNU LD man page contains the following
+warning regarding the -N option:
+
+> Note: Although a writable text section is allowed for PE-COFF targets, it
+> does not conform to the format specification published by Microsoft.
+
+Remove the usage of -N uniformly on all architectures, assuming that the
+addition was simply done as a copy and paste of the original x86 linking
+rune.
+
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Oleksii Kurochko <oleksii.kurochko@gmail.com>
+Acked-by: Julien Grall <jgrall@amazon.com>
+
+diff --git a/xen/arch/arm/Makefile b/xen/arch/arm/Makefile
+index 4d076b278b10..ede54805fec5 100644
+--- a/xen/arch/arm/Makefile
++++ b/xen/arch/arm/Makefile
+@@ -92,17 +92,17 @@ ifeq ($(CONFIG_ARM_64),y)
+ endif
+ 
+ $(TARGET)-syms: $(objtree)/prelink.o $(obj)/xen.lds
+-	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds -N $< \
++	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds $< \
+ 	    $(objtree)/common/symbols-dummy.o -o $(@D)/.$(@F).0
+ 	$(NM) -pa --format=sysv $(@D)/.$(@F).0 \
+ 		| $(objtree)/tools/symbols $(all_symbols) --sysv --sort >$(@D)/.$(@F).0.S
+ 	$(MAKE) $(build)=$(@D) $(@D)/.$(@F).0.o
+-	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds -N $< \
++	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds $< \
+ 	    $(@D)/.$(@F).0.o -o $(@D)/.$(@F).1
+ 	$(NM) -pa --format=sysv $(@D)/.$(@F).1 \
+ 		| $(objtree)/tools/symbols $(all_symbols) --sysv --sort >$(@D)/.$(@F).1.S
+ 	$(MAKE) $(build)=$(@D) $(@D)/.$(@F).1.o
+-	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds -N $< $(build_id_linker) \
++	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds $< $(build_id_linker) \
+ 	    $(@D)/.$(@F).1.o -o $@
+ 	$(NM) -pa --format=sysv $(@D)/$(@F) \
+ 		| $(objtree)/tools/symbols --all-symbols --xensyms --sysv --sort \
+diff --git a/xen/arch/x86/Makefile b/xen/arch/x86/Makefile
+index 6a070a8cf8da..d68946f72a42 100644
+--- a/xen/arch/x86/Makefile
++++ b/xen/arch/x86/Makefile
+@@ -136,19 +136,19 @@ $(TARGET): $(TARGET)-syms $(efi-y) $(obj)/boot/mkelf32
+ CFLAGS-$(XEN_BUILD_EFI) += -DXEN_BUILD_EFI
+ 
+ $(TARGET)-syms: $(objtree)/prelink.o $(obj)/xen.lds
+-	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds -N $< $(build_id_linker) \
++	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds $< $(build_id_linker) \
+ 	    $(objtree)/common/symbols-dummy.o -o $(@D)/.$(@F).0
+ 	$(NM) -pa --format=sysv $(@D)/.$(@F).0 \
+ 		| $(objtree)/tools/symbols $(all_symbols) --sysv --sort \
+ 		>$(@D)/.$(@F).0.S
+ 	$(MAKE) $(build)=$(@D) $(@D)/.$(@F).0.o
+-	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds -N $< $(build_id_linker) \
++	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds $< $(build_id_linker) \
+ 	    $(@D)/.$(@F).0.o -o $(@D)/.$(@F).1
+ 	$(NM) -pa --format=sysv $(@D)/.$(@F).1 \
+ 		| $(objtree)/tools/symbols $(all_symbols) --sysv --sort $(syms-warn-dup-y) \
+ 		>$(@D)/.$(@F).1.S
+ 	$(MAKE) $(build)=$(@D) $(@D)/.$(@F).1.o
+-	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds -N $< $(build_id_linker) \
++	$(LD) $(XEN_LDFLAGS) -T $(obj)/xen.lds $< $(build_id_linker) \
+ 	    $(orphan-handling-y) $(@D)/.$(@F).1.o -o $@
+ 	$(NM) -pa --format=sysv $(@D)/$(@F) \
+ 		| $(objtree)/tools/symbols --all-symbols --xensyms --sysv --sort \
+@@ -209,20 +209,20 @@ ifeq ($(CONFIG_DEBUG_INFO),y)
+ 	$(if $(filter --strip-debug,$(EFI_LDFLAGS)),echo,:) "Will strip debug info from $(@F)"
+ endif
+ 	$(foreach base, $(VIRT_BASE) $(ALT_BASE), \
+-	          $(LD) $(call EFI_LDFLAGS,$(base)) -T $(obj)/efi.lds -N $< $(relocs-dummy) \
++	          $(LD) $(call EFI_LDFLAGS,$(base)) -T $(obj)/efi.lds $< $(relocs-dummy) \
+ 	                $(objtree)/common/symbols-dummy.o $(note_file_option) -o $(@D)/.$(@F).$(base).0 &&) :
+ 	$(MKRELOC) $(foreach base,$(VIRT_BASE) $(ALT_BASE),$(@D)/.$(@F).$(base).0) >$(@D)/.$(@F).0r.S
+ 	$(NM) -pa --format=sysv $(@D)/.$(@F).$(VIRT_BASE).0 \
+ 		| $(objtree)/tools/symbols $(all_symbols) --sysv --sort >$(@D)/.$(@F).0s.S
+ 	$(MAKE) $(build)=$(@D) .$(@F).0r.o .$(@F).0s.o
+ 	$(foreach base, $(VIRT_BASE) $(ALT_BASE), \
+-	          $(LD) $(call EFI_LDFLAGS,$(base)) -T $(obj)/efi.lds -N $< \
++	          $(LD) $(call EFI_LDFLAGS,$(base)) -T $(obj)/efi.lds $< \
+ 	                $(@D)/.$(@F).0r.o $(@D)/.$(@F).0s.o $(note_file_option) -o $(@D)/.$(@F).$(base).1 &&) :
+ 	$(MKRELOC) $(foreach base,$(VIRT_BASE) $(ALT_BASE),$(@D)/.$(@F).$(base).1) >$(@D)/.$(@F).1r.S
+ 	$(NM) -pa --format=sysv $(@D)/.$(@F).$(VIRT_BASE).1 \
+ 		| $(objtree)/tools/symbols $(all_symbols) --sysv --sort >$(@D)/.$(@F).1s.S
+ 	$(MAKE) $(build)=$(@D) .$(@F).1r.o .$(@F).1s.o
+-	$(LD) $(call EFI_LDFLAGS,$(VIRT_BASE)) -T $(obj)/efi.lds -N $< \
++	$(LD) $(call EFI_LDFLAGS,$(VIRT_BASE)) -T $(obj)/efi.lds $< \
+ 	      $(@D)/.$(@F).1r.o $(@D)/.$(@F).1s.o $(orphan-handling-y) $(note_file_option) -o $@
+ 	$(NM) -pa --format=sysv $(@D)/$(@F) \
+ 		| $(objtree)/tools/symbols --all-symbols --xensyms --sysv --sort >$(@D)/$(@F).map

--- a/SOURCES/backport-dd05d265b8ab.patch
+++ b/SOURCES/backport-dd05d265b8ab.patch
@@ -1,9 +1,9 @@
 From dd05d265b8abda4cc7206b29cd71b77fb46658bf Mon Sep 17 00:00:00 2001
 From: Andrew Cooper <andrew.cooper3@citrix.com>
 Date: Tue, 21 Jan 2025 16:56:26 +0000
-Subject: [PATCH] x86/intel: Fix PERF_GLOBAL fixup when virtualised
+Subject: x86/intel: Fix PERF_GLOBAL fixup when virtualised
 MIME-Version: 1.0
-Content-Type: text/plain; charset=utf8
+Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
 Logic using performance counters needs to look at
@@ -23,14 +23,11 @@ Fixes: 6bdb965178bb ("x86/intel: ensure Global Performance Counter Control is se
 Reported-by: Jonathan Katz <jonathan.katz@aptar.com>
 Link: https://xcp-ng.org/forum/topic/10286/nesting-xcp-ng-on-esx-8
 Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
-Reviewed-by: Roger Pau MonnÃ© <roger.pau@citrix.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
 Tested-by: Jonathan Katz <jonathan.katz@aptar.com>
----
- xen/arch/x86/cpu/intel.c | 64 +++++++++++++++++++++++-----------------
- 1 file changed, 37 insertions(+), 27 deletions(-)
 
 diff --git a/xen/arch/x86/cpu/intel.c b/xen/arch/x86/cpu/intel.c
-index 6a7347968b..6a680ba38d 100644
+index 6a7347968ba2..6a680ba38dc9 100644
 --- a/xen/arch/x86/cpu/intel.c
 +++ b/xen/arch/x86/cpu/intel.c
 @@ -535,39 +535,49 @@ static void intel_log_freq(const struct cpuinfo_x86 *c)
@@ -110,6 +107,3 @@ index 6a7347968b..6a680ba38d 100644
  
  	if ( !cpu_has(c, X86_FEATURE_XTOPOLOGY) )
  	{
--- 
-2.39.5
-

--- a/SOURCES/configure-build.patch
+++ b/SOURCES/configure-build.patch
@@ -21,10 +21,10 @@ index 000000000000..55447cd7033f
 +override CONFIG_REMUS_NETBUF := n
 diff --git a/buildconfigs/config-debug b/buildconfigs/config-debug
 new file mode 100644
-index 000000000000..71a3a6dee61b
+index 000000000000..374534ae1d36
 --- /dev/null
 +++ b/buildconfigs/config-debug
-@@ -0,0 +1,158 @@
+@@ -0,0 +1,160 @@
 +#
 +# Automatically generated file; DO NOT EDIT.
 +# Xen/x86 4.17.5 Configuration
@@ -39,6 +39,7 @@ index 000000000000..71a3a6dee61b
 +CONFIG_X86=y
 +CONFIG_ARCH_DEFCONFIG="arch/x86/configs/x86_64_defconfig"
 +CONFIG_CC_HAS_INDIRECT_THUNK=y
++CONFIG_CC_HAS_RETURN_THUNK=y
 +CONFIG_HAS_AS_CET_SS=y
 +CONFIG_HAS_CC_CET_IBT=y
 +
@@ -95,6 +96,7 @@ index 000000000000..71a3a6dee61b
 +# Speculative hardening
 +#
 +CONFIG_INDIRECT_THUNK=y
++CONFIG_RETURN_THUNK=y
 +CONFIG_SPECULATIVE_HARDEN_ARRAY=y
 +CONFIG_SPECULATIVE_HARDEN_BRANCH=y
 +CONFIG_SPECULATIVE_HARDEN_GUEST_ACCESS=y
@@ -185,10 +187,10 @@ index 000000000000..71a3a6dee61b
 +# end of Debugging Options
 diff --git a/buildconfigs/config-pvshim b/buildconfigs/config-pvshim
 new file mode 100644
-index 000000000000..2965e9c6cf73
+index 000000000000..03589ad98c0a
 --- /dev/null
 +++ b/buildconfigs/config-pvshim
-@@ -0,0 +1,142 @@
+@@ -0,0 +1,144 @@
 +#
 +# Automatically generated file; DO NOT EDIT.
 +# Xen/x86 4.17.5 Configuration
@@ -202,6 +204,7 @@ index 000000000000..2965e9c6cf73
 +CONFIG_X86=y
 +CONFIG_ARCH_DEFCONFIG="arch/x86/configs/x86_64_defconfig"
 +CONFIG_CC_HAS_INDIRECT_THUNK=y
++CONFIG_CC_HAS_RETURN_THUNK=y
 +CONFIG_HAS_AS_CET_SS=y
 +CONFIG_HAS_CC_CET_IBT=y
 +
@@ -255,6 +258,7 @@ index 000000000000..2965e9c6cf73
 +# Speculative hardening
 +#
 +CONFIG_INDIRECT_THUNK=y
++CONFIG_RETURN_THUNK=y
 +CONFIG_SPECULATIVE_HARDEN_ARRAY=y
 +CONFIG_SPECULATIVE_HARDEN_BRANCH=y
 +CONFIG_SPECULATIVE_HARDEN_GUEST_ACCESS=y
@@ -333,10 +337,10 @@ index 000000000000..2965e9c6cf73
 +# end of Debugging Options
 diff --git a/buildconfigs/config-release b/buildconfigs/config-release
 new file mode 100644
-index 000000000000..d10379663e45
+index 000000000000..0c3cf97b5d46
 --- /dev/null
 +++ b/buildconfigs/config-release
-@@ -0,0 +1,158 @@
+@@ -0,0 +1,160 @@
 +#
 +# Automatically generated file; DO NOT EDIT.
 +# Xen/x86 4.17.5 Configuration
@@ -351,6 +355,7 @@ index 000000000000..d10379663e45
 +CONFIG_X86=y
 +CONFIG_ARCH_DEFCONFIG="arch/x86/configs/x86_64_defconfig"
 +CONFIG_CC_HAS_INDIRECT_THUNK=y
++CONFIG_CC_HAS_RETURN_THUNK=y
 +CONFIG_HAS_AS_CET_SS=y
 +CONFIG_HAS_CC_CET_IBT=y
 +
@@ -407,6 +412,7 @@ index 000000000000..d10379663e45
 +# Speculative hardening
 +#
 +CONFIG_INDIRECT_THUNK=y
++CONFIG_RETURN_THUNK=y
 +CONFIG_SPECULATIVE_HARDEN_ARRAY=y
 +CONFIG_SPECULATIVE_HARDEN_BRANCH=y
 +CONFIG_SPECULATIVE_HARDEN_GUEST_ACCESS=y
@@ -497,7 +503,7 @@ index 000000000000..d10379663e45
 +# end of Debugging Options
 diff --git a/config/Docs.mk b/config/Docs.mk
 new file mode 100644
-index 000000000000..49616fab6910
+index 000000000000..91cb1550d504
 --- /dev/null
 +++ b/config/Docs.mk
 @@ -0,0 +1,9 @@
@@ -506,7 +512,7 @@ index 000000000000..49616fab6910
 +# Tools
 +FIG2DEV             := 
 +POD2MAN             := /usr/bin/pod2man
-+POD2HTML            := 
++POD2HTML            := /usr/bin/pod2html
 +POD2TEXT            := /usr/bin/pod2text
 +PANDOC              := 
 +PERL                := /usr/bin/perl

--- a/SOURCES/mixed-domain-runstates.patch
+++ b/SOURCES/mixed-domain-runstates.patch
@@ -402,7 +402,7 @@ index 9a3dbf998b56..cb46a5892268 100644
 +    spinlock_t runstate_lock;
 +    atomic_t runstate_missed_changes;
 +    domain_runstate_info_t runstate;
- };
+ } __aligned(PAGE_SIZE);
  
  static inline struct page_list_head *page_to_list(
 @@ -1036,6 +1043,8 @@ int vcpu_affinity_domctl(struct domain *d, uint32_t cmd,

--- a/SOURCES/x86-alternative-Support-replacements-when-a-feature-.patch
+++ b/SOURCES/x86-alternative-Support-replacements-when-a-feature-.patch
@@ -1,0 +1,106 @@
+From 4e61b34b902ca06a43c4a092313a3800ca7c0f1b Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Mon, 21 Apr 2025 15:52:56 +0100
+Subject: x86/alternative: Support replacements when a feature is not present
+
+Use the top bit of a->cpuid to express inverted polarity.  This requires
+stripping the top bit back out when performing the sanity checks.
+
+Despite only being used once, create a replace boolean to express the decision
+more clearly in _apply_alternatives().
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+diff --git a/xen/arch/x86/alternative.c b/xen/arch/x86/alternative.c
+index 5738e03613ed..abcbc5d939c1 100644
+--- a/xen/arch/x86/alternative.c
++++ b/xen/arch/x86/alternative.c
+@@ -209,6 +209,8 @@ static int init_or_livepatch _apply_alternatives(struct alt_instr *start,
+         uint8_t *repl = ALT_REPL_PTR(a);
+         uint8_t buf[MAX_PATCH_LEN];
+         unsigned int total_len = a->orig_len + a->pad_len;
++        unsigned int feat = a->cpuid & ~ALT_FLAG_NOT;
++        bool inv = a->cpuid & ALT_FLAG_NOT, replace;
+ 
+         if ( a->repl_len > total_len )
+         {
+@@ -226,11 +228,11 @@ static int init_or_livepatch _apply_alternatives(struct alt_instr *start,
+             return -ENOSPC;
+         }
+ 
+-        if ( a->cpuid >= NCAPINTS * 32 )
++        if ( feat >= NCAPINTS * 32 )
+         {
+              printk(XENLOG_ERR
+                    "Alt for %ps, feature %#x outside of featureset range %#x\n",
+-                   ALT_ORIG_PTR(a), a->cpuid, NCAPINTS * 32);
++                   ALT_ORIG_PTR(a), feat, NCAPINTS * 32);
+             return -ERANGE;
+         }
+ 
+@@ -255,8 +257,14 @@ static int init_or_livepatch _apply_alternatives(struct alt_instr *start,
+             continue;
+         }
+ 
++        /*
++         * Should a replacement be performed?  Most replacements have positive
++         * polarity, but we support negative polarity too.
++         */
++        replace = boot_cpu_has(feat) ^ inv;
++
+         /* If there is no replacement to make, see about optimising the nops. */
+-        if ( !boot_cpu_has(a->cpuid) )
++        if ( !replace )
+         {
+             /* Origin site site already touched?  Don't nop anything. */
+             if ( base->priv )
+diff --git a/xen/arch/x86/include/asm/alternative-asm.h b/xen/arch/x86/include/asm/alternative-asm.h
+index 57c9c1ebb65e..9935ba907177 100644
+--- a/xen/arch/x86/include/asm/alternative-asm.h
++++ b/xen/arch/x86/include/asm/alternative-asm.h
+@@ -12,7 +12,7 @@
+  * instruction. See apply_alternatives().
+  */
+ .macro altinstruction_entry orig repl feature orig_len repl_len pad_len
+-    .if \feature >= NCAPINTS * 32
++    .if ((\feature) & ~ALT_FLAG_NOT) >= NCAPINTS * 32
+         .error "alternative feature outside of featureset range"
+     .endif
+     .long \orig - .
+diff --git a/xen/arch/x86/include/asm/alternative.h b/xen/arch/x86/include/asm/alternative.h
+index 3d8e7ba9b9e7..4d0032a88a7a 100644
+--- a/xen/arch/x86/include/asm/alternative.h
++++ b/xen/arch/x86/include/asm/alternative.h
+@@ -1,6 +1,13 @@
+ #ifndef __X86_ALTERNATIVE_H__
+ #define __X86_ALTERNATIVE_H__
+ 
++/*
++ * Common to both C and ASM.  Express a replacement when a feature is not
++ * available.
++ */
++#define ALT_FLAG_NOT (1 << 15)
++#define ALT_NOT(x) (ALT_FLAG_NOT | (x))
++
+ #ifdef __ASSEMBLY__
+ #include <asm/alternative-asm.h>
+ #else
+@@ -12,7 +19,7 @@
+ struct __packed alt_instr {
+     int32_t  orig_offset;   /* original instruction */
+     int32_t  repl_offset;   /* offset to replacement instruction */
+-    uint16_t cpuid;         /* cpuid bit set for replacement */
++    uint16_t cpuid;         /* cpuid bit set for replacement (top bit is polarity) */
+     uint8_t  orig_len;      /* length of original instruction */
+     uint8_t  repl_len;      /* length of new instruction */
+     uint8_t  pad_len;       /* length of build-time padding */
+@@ -60,7 +67,7 @@ extern void alternative_branches(void);
+                     alt_repl_len(n2)) "-" alt_orig_len)
+ 
+ #define ALTINSTR_ENTRY(feature, num)                                    \
+-        " .if " STR(feature) " >= " STR(NCAPINTS * 32) "\n"             \
++        " .if (" STR(feature & ~ALT_FLAG_NOT) ") >= " STR(NCAPINTS * 32) "\n" \
+         " .error \"alternative feature outside of featureset range\"\n" \
+         " .endif\n"                                                     \
+         " .long .LXEN%=_orig_s - .\n"             /* label           */ \

--- a/SOURCES/x86-guest-Remove-use-of-the-Xen-hypercall_page.patch
+++ b/SOURCES/x86-guest-Remove-use-of-the-Xen-hypercall_page.patch
@@ -1,0 +1,323 @@
+From 421517e3e33a1d10e7514c9814a95eb14850730b Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Mon, 21 Apr 2025 10:34:02 +0100
+Subject: x86/guest: Remove use of the Xen hypercall_page
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In order to protect against ITS, Xen needs to start using return thunks.
+Therefore the advice in XSA-466 becomes relevant, and the hypercall_page needs
+to be removed.
+
+Implement early_hypercall(), with infrastructure to figure out the correct
+instruction on first use.  Use ALTERNATIVE()s to result in inline hypercalls,
+including the ALT_NOT() form so we only need a single synthetic feature bit.
+
+No overall change.
+
+This is part of XSA-469 / CVE-2024-28956
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+
+diff --git a/xen/arch/x86/guest/xen/Makefile b/xen/arch/x86/guest/xen/Makefile
+index 26fb4b1007c0..8b3250aa8886 100644
+--- a/xen/arch/x86/guest/xen/Makefile
++++ b/xen/arch/x86/guest/xen/Makefile
+@@ -1,4 +1,4 @@
+-obj-y += hypercall_page.o
++obj-bin-y += hypercall.init.o
+ obj-y += xen.o
+ 
+ obj-bin-$(CONFIG_PVH_GUEST) += pvh-boot.init.o
+diff --git a/xen/arch/x86/guest/xen/hypercall.S b/xen/arch/x86/guest/xen/hypercall.S
+new file mode 100644
+index 000000000000..47ab685cf848
+--- /dev/null
++++ b/xen/arch/x86/guest/xen/hypercall.S
+@@ -0,0 +1,52 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++
++#include <asm/asm_defns.h>
++
++        .section .init.text, "ax", @progbits
++
++        /*
++         * Used during early boot, before alternatives have run and inlined
++         * the appropriate instruction.  Called using the hypercall ABI.
++         */
++ENTRY(early_hypercall)
++        cmpb    $0, early_hypercall_insn(%rip)
++        jl      .L_setup
++        je      1f
++
++        vmmcall
++        ret
++
++1:      vmcall
++        ret
++
++.L_setup:
++        /*
++         * When setting up the first time around, all registers need
++         * preserving.  Save the non-callee-saved ones.
++         */
++        push    %r11
++        push    %r10
++        push    %r9
++        push    %r8
++        push    %rdi
++        push    %rsi
++        push    %rdx
++        push    %rcx
++        push    %rax
++
++        call    early_hypercall_setup
++
++        pop     %rax
++        pop     %rcx
++        pop     %rdx
++        pop     %rsi
++        pop     %rdi
++        pop     %r8
++        pop     %r9
++        pop     %r10
++        pop     %r11
++
++        jmp     early_hypercall
++
++        .type early_hypercall, @function
++        .size early_hypercall, . - early_hypercall
+diff --git a/xen/arch/x86/guest/xen/hypercall_page.S b/xen/arch/x86/guest/xen/hypercall_page.S
+deleted file mode 100644
+index 9958d02cfd5b..000000000000
+--- a/xen/arch/x86/guest/xen/hypercall_page.S
++++ /dev/null
+@@ -1,78 +0,0 @@
+-#include <asm/page.h>
+-#include <asm/asm_defns.h>
+-#include <public/xen.h>
+-
+-        .section ".text.page_aligned", "ax", @progbits
+-        .p2align PAGE_SHIFT
+-
+-GLOBAL(hypercall_page)
+-         /* Poisoned with `ret` for safety before hypercalls are set up. */
+-        .fill PAGE_SIZE, 1, 0xc3
+-        .type hypercall_page, STT_OBJECT
+-        .size hypercall_page, PAGE_SIZE
+-
+-/*
+- * Identify a specific hypercall in the hypercall page
+- * @param name Hypercall name.
+- */
+-#define DECLARE_HYPERCALL(name)                                                 \
+-        .globl HYPERCALL_ ## name;                                              \
+-        .type  HYPERCALL_ ## name, STT_FUNC;                                    \
+-        .size  HYPERCALL_ ## name, 32;                                          \
+-        .set   HYPERCALL_ ## name, hypercall_page + __HYPERVISOR_ ## name * 32
+-
+-DECLARE_HYPERCALL(set_trap_table)
+-DECLARE_HYPERCALL(mmu_update)
+-DECLARE_HYPERCALL(set_gdt)
+-DECLARE_HYPERCALL(stack_switch)
+-DECLARE_HYPERCALL(set_callbacks)
+-DECLARE_HYPERCALL(fpu_taskswitch)
+-DECLARE_HYPERCALL(sched_op_compat)
+-DECLARE_HYPERCALL(platform_op)
+-DECLARE_HYPERCALL(set_debugreg)
+-DECLARE_HYPERCALL(get_debugreg)
+-DECLARE_HYPERCALL(update_descriptor)
+-DECLARE_HYPERCALL(memory_op)
+-DECLARE_HYPERCALL(multicall)
+-DECLARE_HYPERCALL(update_va_mapping)
+-DECLARE_HYPERCALL(set_timer_op)
+-DECLARE_HYPERCALL(event_channel_op_compat)
+-DECLARE_HYPERCALL(xen_version)
+-DECLARE_HYPERCALL(console_io)
+-DECLARE_HYPERCALL(physdev_op_compat)
+-DECLARE_HYPERCALL(grant_table_op)
+-DECLARE_HYPERCALL(vm_assist)
+-DECLARE_HYPERCALL(update_va_mapping_otherdomain)
+-DECLARE_HYPERCALL(iret)
+-DECLARE_HYPERCALL(vcpu_op)
+-DECLARE_HYPERCALL(set_segment_base)
+-DECLARE_HYPERCALL(mmuext_op)
+-DECLARE_HYPERCALL(xsm_op)
+-DECLARE_HYPERCALL(nmi_op)
+-DECLARE_HYPERCALL(sched_op)
+-DECLARE_HYPERCALL(callback_op)
+-DECLARE_HYPERCALL(xenoprof_op)
+-DECLARE_HYPERCALL(event_channel_op)
+-DECLARE_HYPERCALL(physdev_op)
+-DECLARE_HYPERCALL(hvm_op)
+-DECLARE_HYPERCALL(sysctl)
+-DECLARE_HYPERCALL(domctl)
+-DECLARE_HYPERCALL(kexec_op)
+-DECLARE_HYPERCALL(argo_op)
+-DECLARE_HYPERCALL(xenpmu_op)
+-
+-DECLARE_HYPERCALL(arch_0)
+-DECLARE_HYPERCALL(arch_1)
+-DECLARE_HYPERCALL(arch_2)
+-DECLARE_HYPERCALL(arch_3)
+-DECLARE_HYPERCALL(arch_4)
+-DECLARE_HYPERCALL(arch_5)
+-DECLARE_HYPERCALL(arch_6)
+-DECLARE_HYPERCALL(arch_7)
+-
+-/*
+- * Local variables:
+- * tab-width: 8
+- * indent-tabs-mode: nil
+- * End:
+- */
+diff --git a/xen/arch/x86/guest/xen/xen.c b/xen/arch/x86/guest/xen/xen.c
+index c4cb16df38b3..0d1e6d06586b 100644
+--- a/xen/arch/x86/guest/xen/xen.c
++++ b/xen/arch/x86/guest/xen/xen.c
+@@ -38,7 +38,6 @@
+ bool __read_mostly xen_guest;
+ 
+ uint32_t __read_mostly xen_cpuid_base;
+-extern char hypercall_page[];
+ static struct rangeset *mem;
+ 
+ DEFINE_PER_CPU(unsigned int, vcpu_id);
+@@ -47,6 +46,50 @@ static struct vcpu_info *vcpu_info;
+ static unsigned long vcpu_info_mapped[BITS_TO_LONGS(NR_CPUS)];
+ DEFINE_PER_CPU(struct vcpu_info *, vcpu_info);
+ 
++/*
++ * Which instruction to use for early hypercalls:
++ *   < 0 setup
++ *     0 vmcall
++ *   > 0 vmmcall
++ */
++int8_t __initdata early_hypercall_insn = -1;
++
++/*
++ * Called once during the first hypercall to figure out which instruction to
++ * use.  Error handling options are limited.
++ */
++void __init early_hypercall_setup(void)
++{
++    BUG_ON(early_hypercall_insn != -1);
++
++    if ( !boot_cpu_data.x86_vendor )
++    {
++        unsigned int eax, ebx, ecx, edx;
++
++        cpuid(0, &eax, &ebx, &ecx, &edx);
++
++        boot_cpu_data.x86_vendor = x86_cpuid_lookup_vendor(ebx, ecx, edx);
++    }
++
++    switch ( boot_cpu_data.x86_vendor )
++    {
++    case X86_VENDOR_INTEL:
++    case X86_VENDOR_CENTAUR:
++    case X86_VENDOR_SHANGHAI:
++        early_hypercall_insn = 0;
++        setup_force_cpu_cap(X86_FEATURE_USE_VMCALL);
++        break;
++
++    case X86_VENDOR_AMD:
++    case X86_VENDOR_HYGON:
++        early_hypercall_insn = 1;
++        break;
++
++    default:
++        BUG();
++    }
++}
++
+ static void __init find_xen_leaves(void)
+ {
+     uint32_t eax, ebx, ecx, edx, base;
+@@ -349,9 +392,6 @@ const struct hypervisor_ops *__init xg_probe(void)
+     if ( !xen_cpuid_base )
+         return NULL;
+ 
+-    /* Fill the hypercall page. */
+-    wrmsrl(cpuid_ebx(xen_cpuid_base + 2), __pa(hypercall_page));
+-
+     xen_guest = true;
+ 
+     return &ops;
+diff --git a/xen/arch/x86/include/asm/cpufeatures.h b/xen/arch/x86/include/asm/cpufeatures.h
+index ba3df174b76e..9e3ed21c026d 100644
+--- a/xen/arch/x86/include/asm/cpufeatures.h
++++ b/xen/arch/x86/include/asm/cpufeatures.h
+@@ -42,6 +42,7 @@ XEN_CPUFEATURE(XEN_SHSTK,         X86_SYNTH(26)) /* Xen uses CET Shadow Stacks *
+ XEN_CPUFEATURE(XEN_IBT,           X86_SYNTH(27)) /* Xen uses CET Indirect Branch Tracking */
+ XEN_CPUFEATURE(IBPB_ENTRY_PV,     X86_SYNTH(28)) /* MSR_PRED_CMD used by Xen for PV */
+ XEN_CPUFEATURE(IBPB_ENTRY_HVM,    X86_SYNTH(29)) /* MSR_PRED_CMD used by Xen for HVM */
++XEN_CPUFEATURE(USE_VMCALL,        X86_SYNTH(30)) /* Use VMCALL instead of VMMCALL */
+ 
+ /* Bug words follow the synthetic words. */
+ #define X86_NR_BUG 1
+diff --git a/xen/arch/x86/include/asm/guest/xen-hcall.h b/xen/arch/x86/include/asm/guest/xen-hcall.h
+index 03d5868a9efd..a7e90adbafb7 100644
+--- a/xen/arch/x86/include/asm/guest/xen-hcall.h
++++ b/xen/arch/x86/include/asm/guest/xen-hcall.h
+@@ -41,9 +41,11 @@
+     ({                                                                  \
+         long res, tmp__;                                                \
+         asm volatile (                                                  \
+-            "call hypercall_page + %c[offset]"                          \
++            ALTERNATIVE_2("call early_hypercall",                       \
++                          "vmmcall", ALT_NOT(X86_FEATURE_USE_VMCALL),   \
++                          "vmcall", X86_FEATURE_USE_VMCALL)             \
+             : "=a" (res), "=D" (tmp__) ASM_CALL_CONSTRAINT              \
+-            : [offset] "i" (hcall * 32),                                \
++            : "0" (hcall),                                              \
+               "1" ((long)(a1))                                          \
+             : "memory" );                                               \
+         (type)res;                                                      \
+@@ -53,10 +55,12 @@
+     ({                                                                  \
+         long res, tmp__;                                                \
+         asm volatile (                                                  \
+-            "call hypercall_page + %c[offset]"                          \
++            ALTERNATIVE_2("call early_hypercall",                       \
++                          "vmmcall", ALT_NOT(X86_FEATURE_USE_VMCALL),   \
++                          "vmcall", X86_FEATURE_USE_VMCALL)             \
+             : "=a" (res), "=D" (tmp__), "=S" (tmp__)                    \
+               ASM_CALL_CONSTRAINT                                       \
+-            : [offset] "i" (hcall * 32),                                \
++            : "0" (hcall),                                              \
+               "1" ((long)(a1)), "2" ((long)(a2))                        \
+             : "memory" );                                               \
+         (type)res;                                                      \
+@@ -66,10 +70,12 @@
+     ({                                                                  \
+         long res, tmp__;                                                \
+         asm volatile (                                                  \
+-            "call hypercall_page + %c[offset]"                          \
++            ALTERNATIVE_2("call early_hypercall",                       \
++                          "vmmcall", ALT_NOT(X86_FEATURE_USE_VMCALL),   \
++                          "vmcall", X86_FEATURE_USE_VMCALL)             \
+             : "=a" (res), "=D" (tmp__), "=S" (tmp__), "=d" (tmp__)      \
+               ASM_CALL_CONSTRAINT                                       \
+-            : [offset] "i" (hcall * 32),                                \
++            : "0" (hcall),                                              \
+               "1" ((long)(a1)), "2" ((long)(a2)), "3" ((long)(a3))      \
+             : "memory" );                                               \
+         (type)res;                                                      \
+@@ -80,10 +86,12 @@
+         long res, tmp__;                                                \
+         register long _a4 asm ("r10") = ((long)(a4));                   \
+         asm volatile (                                                  \
+-            "call hypercall_page + %c[offset]"                          \
++            ALTERNATIVE_2("call early_hypercall",                       \
++                          "vmmcall", ALT_NOT(X86_FEATURE_USE_VMCALL),   \
++                          "vmcall", X86_FEATURE_USE_VMCALL)             \
+             : "=a" (res), "=D" (tmp__), "=S" (tmp__), "=d" (tmp__),     \
+               "=&r" (tmp__) ASM_CALL_CONSTRAINT                         \
+-            : [offset] "i" (hcall * 32),                                \
++            : "0" (hcall),                                              \
+               "1" ((long)(a1)), "2" ((long)(a2)), "3" ((long)(a3)),     \
+               "4" (_a4)                                                 \
+             : "memory" );                                               \

--- a/SOURCES/x86-spec-ctrl-Intel-PB-OPT.patch
+++ b/SOURCES/x86-spec-ctrl-Intel-PB-OPT.patch
@@ -1,0 +1,142 @@
+From 99a6ea40e09f76727e16c1972127bb5005ed1cb2 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Thu, 24 Apr 2025 16:51:00 +0100
+Subject: x86/spec-ctrl: Intel PB-OPT
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+diff --git a/xen/arch/x86/acpi/power.c b/xen/arch/x86/acpi/power.c
+index e43b26612335..bbe06752109b 100644
+--- a/xen/arch/x86/acpi/power.c
++++ b/xen/arch/x86/acpi/power.c
+@@ -300,6 +300,7 @@ static int enter_state(u32 state)
+     }
+ 
+     update_mcu_opt_ctrl();
++    update_pb_opt_ctrl();
+ 
+     /*
+      * This should be before restoring CR4, but that is earlier in asm and
+diff --git a/xen/arch/x86/cpu/intel.c b/xen/arch/x86/cpu/intel.c
+index 2494d4c64ec7..72e11db197a2 100644
+--- a/xen/arch/x86/cpu/intel.c
++++ b/xen/arch/x86/cpu/intel.c
+@@ -49,6 +49,34 @@ void __init set_in_mcu_opt_ctrl(uint32_t mask, uint32_t val)
+     update_mcu_opt_ctrl();
+ }
+ 
++static uint32_t __ro_after_init pb_opt_ctrl_mask;
++static uint32_t __ro_after_init pb_opt_ctrl_val;
++
++void update_pb_opt_ctrl(void)
++{
++    uint32_t mask = pb_opt_ctrl_mask, lo, hi;
++
++    if ( !mask )
++        return;
++
++    rdmsr(MSR_PB_OPT_CTRL, lo, hi);
++
++    lo &= ~mask;
++    lo |= pb_opt_ctrl_val;
++
++    wrmsr(MSR_PB_OPT_CTRL, lo, hi);
++}
++
++void __init set_in_pb_opt_ctrl(uint32_t mask, uint32_t val)
++{
++    pb_opt_ctrl_mask |= mask;
++
++    pb_opt_ctrl_val &= ~mask;
++    pb_opt_ctrl_val |= (val & mask);
++
++    update_pb_opt_ctrl();
++}
++
+ /*
+  * Processors which have self-snooping capability can handle conflicting
+  * memory type across CPUs by snooping its own cache. However, there exists
+diff --git a/xen/arch/x86/include/asm/msr-index.h b/xen/arch/x86/include/asm/msr-index.h
+index 340716188e0f..db602fdbfeeb 100644
+--- a/xen/arch/x86/include/asm/msr-index.h
++++ b/xen/arch/x86/include/asm/msr-index.h
+@@ -55,6 +55,9 @@
+ #define MSR_MISC_PACKAGE_CTRL               0x000000bc
+ #define  PGK_CTRL_ENERGY_FILTER_EN          (_AC(1, ULL) <<  0)
+ 
++#define MSR_PB_OPT_CTRL                     0x000000bf
++#define  PB_OPT_IBPB_ALT                    (_AC(1, ULL) <<  0)
++
+ #define MSR_CORE_CAPABILITIES               0x000000cf
+ #define  CORE_CAPS_SPLITLOCK_DETECT         (_AC(1, ULL) <<  5)
+ 
+diff --git a/xen/arch/x86/include/asm/processor.h b/xen/arch/x86/include/asm/processor.h
+index 7925e6b911f2..ad17f4c8b1a5 100644
+--- a/xen/arch/x86/include/asm/processor.h
++++ b/xen/arch/x86/include/asm/processor.h
+@@ -593,6 +593,9 @@ void tsx_init(void);
+ void update_mcu_opt_ctrl(void);
+ void set_in_mcu_opt_ctrl(uint32_t mask, uint32_t val);
+ 
++void update_pb_opt_ctrl(void);
++void set_in_pb_opt_ctrl(uint32_t mask, uint32_t val);
++
+ enum ap_boot_method {
+     AP_BOOT_NORMAL,
+     AP_BOOT_SKINIT,
+diff --git a/xen/arch/x86/smpboot.c b/xen/arch/x86/smpboot.c
+index 66e7564ef1d8..0b1c1c51c2a1 100644
+--- a/xen/arch/x86/smpboot.c
++++ b/xen/arch/x86/smpboot.c
+@@ -390,6 +390,7 @@ void start_secondary(void *unused)
+         info->last_spec_ctrl = default_xen_spec_ctrl;
+     }
+     update_mcu_opt_ctrl();
++    update_pb_opt_ctrl();
+ 
+     tsx_init(); /* Needs microcode.  May change HLE/RTM feature bits. */
+ 
+diff --git a/xen/arch/x86/spec_ctrl.c b/xen/arch/x86/spec_ctrl.c
+index 288b80a0bf12..a8419c0560a0 100644
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -97,6 +97,8 @@ static int8_t __initdata opt_gds_mit = -1;
+ static int8_t __initdata opt_div_scrub = -1;
+ bool __ro_after_init opt_bp_spec_reduce = true;
+ 
++static __initdata bool opt_ibpb_alt;
++
+ static int __init cf_check parse_spec_ctrl(const char *s)
+ {
+     const char *ss;
+@@ -379,6 +381,8 @@ static int __init cf_check parse_spec_ctrl(const char *s)
+             opt_div_scrub = val;
+         else if ( (val = parse_boolean("bp-spec-reduce", s, ss)) >= 0 )
+             opt_bp_spec_reduce = val;
++        else if ( (val = parse_boolean("ibpb-alt", s, ss)) >= 0 )
++            opt_ibpb_alt = val;
+         else
+             rc = -EINVAL;
+ 
+@@ -2521,6 +2525,9 @@ void __init init_speculation_mitigations(void)
+         wrmsrl(MSR_SPEC_CTRL, val);
+         info->last_spec_ctrl = val;
+     }
++
++    if ( boot_cpu_has(X86_FEATURE_PB_OPT_CTRL) )
++        set_in_pb_opt_ctrl(PB_OPT_IBPB_ALT, opt_ibpb_alt);
+ }
+ 
+ static void __init __maybe_unused build_assertions(void)
+diff --git a/xen/include/public/arch-x86/cpufeatureset.h b/xen/include/public/arch-x86/cpufeatureset.h
+index c4ae07d1ff06..956dcd1f8385 100644
+--- a/xen/include/public/arch-x86/cpufeatureset.h
++++ b/xen/include/public/arch-x86/cpufeatureset.h
+@@ -344,6 +344,7 @@ XEN_CPUFEATURE(RFDS_NO,            16*32+27) /*A  No Register File Data Sampling
+ XEN_CPUFEATURE(RFDS_CLEAR,         16*32+28) /*!A| Register File(s) cleared by VERW */
+ 
+ /* Intel-defined CPU features, MSR_ARCH_CAPS 0x10a.edx, word 17 (express in terms of word 16) */
++XEN_CPUFEATURE(PB_OPT_CTRL,        16*32+32) /*   MSR_PB_OPT_CTRL.IBPB_ALT */
+ XEN_CPUFEATURE(ITS_NO,             16*32+62) /*!A No Indirect Target Selection */
+ 
+ #endif /* XEN_CPUFEATURE */

--- a/SOURCES/x86-spec-ctrl-Synthesise-ITS_NO-to-guests-on-unaffec.patch
+++ b/SOURCES/x86-spec-ctrl-Synthesise-ITS_NO-to-guests-on-unaffec.patch
@@ -1,0 +1,159 @@
+From aab0a688a8b552dfbe9463d7408b0feb33dffbf0 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Thu, 9 May 2024 17:43:47 +0100
+Subject: x86/spec-ctrl: Synthesise ITS_NO to guests on unaffected hardware
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It is easier to express feature word 17 in terms of word 16 + [32, 64) as
+that's how the layout is given in documentation.
+
+This is part of XSA-469 / CVE-2024-28956
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+
+diff --git a/xen/arch/x86/include/asm/cpufeature.h b/xen/arch/x86/include/asm/cpufeature.h
+index c059287d2c73..df2ffb660005 100644
+--- a/xen/arch/x86/include/asm/cpufeature.h
++++ b/xen/arch/x86/include/asm/cpufeature.h
+@@ -167,6 +167,7 @@
+ #define cpu_has_gds_no          boot_cpu_has(X86_FEATURE_GDS_NO)
+ #define cpu_has_rfds_no         boot_cpu_has(X86_FEATURE_RFDS_NO)
+ #define cpu_has_rfds_clear      boot_cpu_has(X86_FEATURE_RFDS_CLEAR)
++#define cpu_has_its_no          boot_cpu_has(X86_FEATURE_ITS_NO)
+ 
+ /* Synthesized. */
+ #define cpu_has_arch_perfmon    boot_cpu_has(X86_FEATURE_ARCH_PERFMON)
+diff --git a/xen/arch/x86/spec_ctrl.c b/xen/arch/x86/spec_ctrl.c
+index bbd419a4857a..288b80a0bf12 100644
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -1793,6 +1793,90 @@ static void __init bhi_calculations(void)
+     }
+ }
+ 
++/*
++ * https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/advisory-guidance/indirect-target-selection.html
++ */
++static void __init its_calculations(void)
++{
++    /*
++     * Indirect Target Selection is a Branch Prediction bug whereby certain
++     * indirect branches (including RETs) get predicted using a direct branch
++     * target, rather than a suitable indirect target, bypassing hardware
++     * isolation protections.
++     *
++     * ITS affects Core (but not Atom) processors starting from the
++     * introduction of eIBRS, up to but not including Golden Cove cores
++     * (checked here with BHI_CTRL).
++     *
++     * The ITS_NO feature is not expected to be enumerated by hardware, and is
++     * only for VMMs to synthesise for guests.
++     *
++     * ITS comes in 3 flavours:
++     *
++     *   1) Across-IBPB.  Indirect branches after the IBPB can be controlled
++     *      by direct targets which existed prior to the IBPB.  This is
++     *      addressed in the IPU 2025.1 microcode drop, and has no other
++     *      software interaction.
++     *
++     *   2) Guest/Host.  Indirect branches in the VMM can be controlled by
++     *      direct targets from the guest.  This applies equally to PV guests
++     *      (Ring3) and HVM guests (VMX), and applies to all Skylake-uarch
++     *      cores with eIBRS.
++     *
++     *   3) Intra-mode.  Indirect branches in the VMM can be controlled by
++     *      other execution in the same mode.
++     */
++
++    /*
++     * If we can see ITS_NO, or we're virtualised, do nothing.  We are or may
++     * migrate somewhere unsafe.
++     */
++    if ( cpu_has_its_no || cpu_has_hypervisor )
++        return;
++
++    /* ITS is only known to affect Intel processors at this time. */
++    if ( boot_cpu_data.x86_vendor != X86_VENDOR_INTEL )
++        return;
++
++    /*
++     * ITS does not exist on:
++     *  - non-Family 6 CPUs
++     *  - those without eIBRS
++     *  - those with BHI_CTRL
++     * but we still need to synthesise ITS_NO.
++     */
++    if ( boot_cpu_data.x86 != 6 || !cpu_has_eibrs ||
++         boot_cpu_has(X86_FEATURE_BHI_CTRL) )
++        goto syntesise;
++
++    switch ( boot_cpu_data.x86_model )
++    {
++        /* These Skylake-uarch cores suffer cases #2 and #3. */
++    case INTEL_FAM6_SKYLAKE_X:
++    case INTEL_FAM6_KABYLAKE_L:
++    case INTEL_FAM6_KABYLAKE:
++    case INTEL_FAM6_COMETLAKE:
++    case INTEL_FAM6_COMETLAKE_L:
++        return;
++
++        /* These Sunny/Willow/Cypress Cove cores suffer case #3. */
++    case INTEL_FAM6_ICELAKE_X:
++    case INTEL_FAM6_ICELAKE_D:
++    case INTEL_FAM6_ICELAKE_L:
++    case INTEL_FAM6_TIGERLAKE_L:
++    case INTEL_FAM6_TIGERLAKE:
++    case INTEL_FAM6_ROCKETLAKE:
++        return;
++
++    default:
++        break;
++    }
++
++    /* Platforms remaining are not believed to be vulnerable to ITS. */
++ syntesise:
++    setup_force_cpu_cap(X86_FEATURE_ITS_NO);
++}
++
+ void spec_ctrl_init_domain(struct domain *d)
+ {
+     bool pv = is_pv_domain(d);
+@@ -2343,6 +2427,8 @@ void __init init_speculation_mitigations(void)
+ 
+     bhi_calculations();
+ 
++    its_calculations();
++
+     print_details(thunk);
+ 
+     /*
+diff --git a/xen/include/public/arch-x86/cpufeatureset.h b/xen/include/public/arch-x86/cpufeatureset.h
+index 30b5087a3fec..c4ae07d1ff06 100644
+--- a/xen/include/public/arch-x86/cpufeatureset.h
++++ b/xen/include/public/arch-x86/cpufeatureset.h
+@@ -343,7 +343,8 @@ XEN_CPUFEATURE(GDS_NO,             16*32+26) /*A  No Gather Data Sampling */
+ XEN_CPUFEATURE(RFDS_NO,            16*32+27) /*A  No Register File Data Sampling */
+ XEN_CPUFEATURE(RFDS_CLEAR,         16*32+28) /*!A| Register File(s) cleared by VERW */
+ 
+-/* Intel-defined CPU features, MSR_ARCH_CAPS 0x10a.edx, word 17 */
++/* Intel-defined CPU features, MSR_ARCH_CAPS 0x10a.edx, word 17 (express in terms of word 16) */
++XEN_CPUFEATURE(ITS_NO,             16*32+62) /*!A No Indirect Target Selection */
+ 
+ #endif /* XEN_CPUFEATURE */
+ 
+diff --git a/xen/tools/gen-cpuid.py b/xen/tools/gen-cpuid.py
+index d48101ce459c..278e9cb4310a 100755
+--- a/xen/tools/gen-cpuid.py
++++ b/xen/tools/gen-cpuid.py
+@@ -51,7 +51,7 @@ def parse_definitions(state):
+         r"\s+/\*([\w!|]*) .*$")
+ 
+     word_regex = re.compile(
+-        r"^/\* .* word (\d*) \*/$")
++        r"^/\* .* word (\d*) .*\*/$")
+     last_word = -1
+ 
+     this = sys.modules[__name__]

--- a/SOURCES/x86-stubs-Introduce-place_ret-to-abstract-away-raw-0.patch
+++ b/SOURCES/x86-stubs-Introduce-place_ret-to-abstract-away-raw-0.patch
@@ -1,0 +1,507 @@
+From 0ad35e00881a28edafbc7fcad4f46ab8db5ba371 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Sun, 4 May 2025 22:44:42 +0100
+Subject: x86/stubs: Introduce place_ret() to abstract away raw 0xc3's
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Indirect Target Selection speculative vulnerability means that indirect
+branches (including RETs) are unsafe when in the first half of a cacheline.
+This means it's not safe for logic using the stubs to write raw 0xc3's.
+
+Introduce place_ret() which, for now, writes a raw 0xc3 but will contain
+additional logic when return thunks are in use.
+
+stub_selftest() doesn't strictly need to be converted as they only run on
+boot, but doing so gets us a partial test of place_ret() too.
+
+No functional change.
+
+This is part of XSA-469 / CVE-2024-28956
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+
+diff --git a/tools/tests/x86_emulator/x86-emulate.h b/tools/tests/x86_emulator/x86-emulate.h
+index 9112e684edea..94664f97197b 100644
+--- a/tools/tests/x86_emulator/x86-emulate.h
++++ b/tools/tests/x86_emulator/x86-emulate.h
+@@ -64,6 +64,12 @@
+ 
+ #define is_canonical_address(x) (((int64_t)(x) >> 47) == ((int64_t)(x) >> 63))
+ 
++static inline void *place_ret(void *ptr)
++{
++    *(uint8_t *)ptr = 0xc3;
++    return ptr + 1;
++}
++
+ extern uint32_t mxcsr_mask;
+ extern struct cpu_policy cp;
+ 
+diff --git a/xen/arch/x86/Makefile b/xen/arch/x86/Makefile
+index d68946f72a42..fd73b6d06bcc 100644
+--- a/xen/arch/x86/Makefile
++++ b/xen/arch/x86/Makefile
+@@ -10,9 +10,7 @@ obj-$(CONFIG_XENOPROF) += oprofile/
+ obj-$(CONFIG_PV) += pv/
+ obj-y += x86_64/
+ 
+-alternative-y := alternative.init.o
+-alternative-$(CONFIG_LIVEPATCH) :=
+-obj-bin-y += $(alternative-y)
++obj-y += alternative.o
+ obj-y += apic.o
+ obj-y += bhb-thunk.o
+ obj-y += bitops.o
+@@ -40,7 +38,7 @@ obj-y += hypercall.o
+ obj-y += i387.o
+ obj-y += i8259.o
+ obj-y += io_apic.o
+-obj-$(CONFIG_LIVEPATCH) += alternative.o livepatch.o
++obj-$(CONFIG_LIVEPATCH) += livepatch.o
+ obj-y += msi.o
+ obj-y += msr.o
+ obj-$(CONFIG_INDIRECT_THUNK) += indirect-thunk.o
+diff --git a/xen/arch/x86/alternative.c b/xen/arch/x86/alternative.c
+index abcbc5d939c1..8e5f3e63f84c 100644
+--- a/xen/arch/x86/alternative.c
++++ b/xen/arch/x86/alternative.c
+@@ -149,6 +149,20 @@ void init_or_livepatch add_nops(void *insns, unsigned int len)
+     }
+ }
+ 
++/*
++ * Place a return at @ptr.  @ptr must be in the writable alias of a stub.
++ *
++ * Returns the next position to write into the stub.
++ */
++void *place_ret(void *ptr)
++{
++    uint8_t *p = ptr;
++
++    *p++ = 0xc3;
++
++    return p;
++}
++
+ /*
+  * text_poke - Update instructions on a live kernel or non-executed code.
+  * @addr: address to modify
+diff --git a/xen/arch/x86/extable.c b/xen/arch/x86/extable.c
+index f05c16def68b..adfd439d3a50 100644
+--- a/xen/arch/x86/extable.c
++++ b/xen/arch/x86/extable.c
+@@ -135,20 +135,20 @@ search_exception_table(const struct cpu_user_regs *regs, unsigned long *stub_ra)
+ int __init cf_check stub_selftest(void)
+ {
+     static const struct {
+-        uint8_t opc[8];
++        uint8_t opc[7];
+         uint64_t rax;
+         union stub_exception_token res;
+     } tests[] __initconst = {
+ #define endbr64 0xf3, 0x0f, 0x1e, 0xfa
+-        { .opc = { endbr64, 0x0f, 0xb9, 0xc3, 0xc3 }, /* ud1 */
++        { .opc = { endbr64, 0x0f, 0xb9, 0x90 }, /* ud1 */
+           .res.fields.trapnr = TRAP_invalid_op },
+-        { .opc = { endbr64, 0x90, 0x02, 0x00, 0xc3 }, /* nop; add (%rax),%al */
++        { .opc = { endbr64, 0x90, 0x02, 0x00 }, /* nop; add (%rax),%al */
+           .rax = 0x0123456789abcdef,
+           .res.fields.trapnr = TRAP_gp_fault },
+-        { .opc = { endbr64, 0x02, 0x04, 0x04, 0xc3 }, /* add (%rsp,%rax),%al */
++        { .opc = { endbr64, 0x02, 0x04, 0x04 }, /* add (%rsp,%rax),%al */
+           .rax = 0xfedcba9876543210,
+           .res.fields.trapnr = TRAP_stack_error },
+-        { .opc = { endbr64, 0xcc, 0xc3, 0xc3, 0xc3 }, /* int3 */
++        { .opc = { endbr64, 0xcc, 0x90, 0x90 }, /* int3 */
+           .res.fields.trapnr = TRAP_int3 },
+ #undef endbr64
+     };
+@@ -167,6 +167,7 @@ int __init cf_check stub_selftest(void)
+ 
+         memset(ptr, 0xcc, STUB_BUF_SIZE / 2);
+         memcpy(ptr, tests[i].opc, ARRAY_SIZE(tests[i].opc));
++        place_ret(ptr + ARRAY_SIZE(tests[i].opc));
+         unmap_domain_page(ptr);
+ 
+         asm volatile ( "INDIRECT_CALL %[stb]\n"
+diff --git a/xen/arch/x86/include/asm/alternative.h b/xen/arch/x86/include/asm/alternative.h
+index 4d0032a88a7a..4855bbc9cb48 100644
+--- a/xen/arch/x86/include/asm/alternative.h
++++ b/xen/arch/x86/include/asm/alternative.h
+@@ -31,6 +31,8 @@ struct __packed alt_instr {
+ #define ALT_REPL_PTR(a)     __ALT_PTR(a, repl_offset)
+ 
+ extern void add_nops(void *insns, unsigned int len);
++void *place_ret(void *ptr);
++
+ /* Similar to alternative_instructions except it can be run with IRQs enabled. */
+ extern int apply_alternatives(struct alt_instr *start, struct alt_instr *end);
+ extern void alternative_instructions(void);
+diff --git a/xen/arch/x86/pv/emul-priv-op.c b/xen/arch/x86/pv/emul-priv-op.c
+index 0f0273b27a1c..949cec4e16ae 100644
+--- a/xen/arch/x86/pv/emul-priv-op.c
++++ b/xen/arch/x86/pv/emul-priv-op.c
+@@ -88,7 +88,6 @@ static io_emul_stub_t *io_emul_stub_setup(struct priv_op_ctxt *ctxt, u8 opcode,
+         0x41, 0x5c, /* pop %r12  */
+         0x5d,       /* pop %rbp  */
+         0x5b,       /* pop %rbx  */
+-        0xc3,       /* ret       */
+     };
+ 
+     const struct stubs *this_stubs = &this_cpu(stubs);
+@@ -138,11 +137,13 @@ static io_emul_stub_t *io_emul_stub_setup(struct priv_op_ctxt *ctxt, u8 opcode,
+ 
+     APPEND_CALL(save_guest_gprs);
+     APPEND_BUFF(epilogue);
++    p = place_ret(p);
+ 
+     /* Build-time best effort attempt to catch problems. */
+     BUILD_BUG_ON(STUB_BUF_SIZE / 2 <
+                  (sizeof(prologue) + sizeof(epilogue) + 10 /* 2x call */ +
+-                  MAX(3 /* default stub */, IOEMUL_QUIRK_STUB_BYTES)));
++                  MAX(3 /* default stub */, IOEMUL_QUIRK_STUB_BYTES) +
++                  1 /* ret */));
+     /* Runtime confirmation that we haven't clobbered an adjacent stub. */
+     BUG_ON(STUB_BUF_SIZE / 2 < (p - ctxt->io_emul_stub));
+ 
+diff --git a/xen/arch/x86/x86_emulate/x86_emulate.c b/xen/arch/x86/x86_emulate/x86_emulate.c
+index 466d758c9b85..a2506b71597a 100644
+--- a/xen/arch/x86/x86_emulate/x86_emulate.c
++++ b/xen/arch/x86/x86_emulate/x86_emulate.c
+@@ -1533,36 +1533,42 @@ static inline bool fpu_check_write(void)
+ 
+ #define emulate_fpu_insn_memdst(opc, ext, arg)                          \
+ do {                                                                    \
++    void *_p = get_stub(stub);                                          \
+     /* ModRM: mod=0, reg=ext, rm=0, i.e. a (%rax) operand */            \
+     insn_bytes = 2;                                                     \
+-    memcpy(get_stub(stub),                                              \
+-           ((uint8_t[]){ opc, ((ext) & 7) << 3, 0xc3 }), 3);            \
++    memcpy(_p, ((uint8_t[]){ opc, ((ext) & 7) << 3 }), 2); _p += 2;     \
++    place_ret(_p);                                                      \
+     invoke_stub("", "", "+m" (arg) : "a" (&(arg)));                     \
+     put_stub(stub);                                                     \
+ } while (0)
+ 
+ #define emulate_fpu_insn_memsrc(opc, ext, arg)                          \
+ do {                                                                    \
++    void *_p = get_stub(stub);                                          \
+     /* ModRM: mod=0, reg=ext, rm=0, i.e. a (%rax) operand */            \
+-    memcpy(get_stub(stub),                                              \
+-           ((uint8_t[]){ opc, ((ext) & 7) << 3, 0xc3 }), 3);            \
++    memcpy(_p, ((uint8_t[]){ opc, ((ext) & 7) << 3 }), 2); _p += 2;     \
++    place_ret(_p);                                                      \
+     invoke_stub("", "", "=m" (dummy) : "m" (arg), "a" (&(arg)));        \
+     put_stub(stub);                                                     \
+ } while (0)
+ 
+ #define emulate_fpu_insn_stub(bytes...)                                 \
+ do {                                                                    \
++    void *_p = get_stub(stub);                                          \
+     unsigned int nr_ = sizeof((uint8_t[]){ bytes });                    \
+-    memcpy(get_stub(stub), ((uint8_t[]){ bytes, 0xc3 }), nr_ + 1);      \
++    memcpy(_p, ((uint8_t[]){ bytes }), nr_); _p += nr_;                 \
++    place_ret(_p);                                                      \
+     invoke_stub("", "", "=m" (dummy) : "i" (0));                        \
+     put_stub(stub);                                                     \
+ } while (0)
+ 
+ #define emulate_fpu_insn_stub_eflags(bytes...)                          \
+ do {                                                                    \
++    void *_p = get_stub(stub);                                          \
+     unsigned int nr_ = sizeof((uint8_t[]){ bytes });                    \
+     unsigned long tmp_;                                                 \
+-    memcpy(get_stub(stub), ((uint8_t[]){ bytes, 0xc3 }), nr_ + 1);      \
++    memcpy(_p, ((uint8_t[]){ bytes }), nr_); _p += nr_;                 \
++    place_ret(_p);                                                      \
+     invoke_stub(_PRE_EFLAGS("[eflags]", "[mask]", "[tmp]"),             \
+                 _POST_EFLAGS("[eflags]", "[mask]", "[tmp]"),            \
+                 [eflags] "+g" (_regs.eflags), [tmp] "=&r" (tmp_)        \
+@@ -3853,7 +3859,7 @@ x86_emulate(
+         stb[3] = 0x91;
+         stb[4] = evex.opmsk << 3;
+         insn_bytes = 5;
+-        stb[5] = 0xc3;
++        place_ret(&stb[5]);
+ 
+         invoke_stub("", "", "+m" (op_mask) : "a" (&op_mask));
+ 
+@@ -6766,7 +6772,7 @@ x86_emulate(
+             evex.lr = 0;
+         opc[1] = (modrm & 0x38) | 0xc0;
+         insn_bytes = EVEX_PFX_BYTES + 2;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         copy_EVEX(opc, evex);
+         invoke_stub("", "", "=g" (dummy) : "a" (src.val));
+@@ -6831,7 +6837,7 @@ x86_emulate(
+             insn_bytes = PFX_BYTES + 2;
+             copy_REX_VEX(opc, rex_prefix, vex);
+         }
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         ea.reg = decode_gpr(&_regs, modrm_reg);
+         invoke_stub("", "", "=a" (*ea.reg) : "c" (mmvalp), "m" (*mmvalp));
+@@ -6899,7 +6905,7 @@ x86_emulate(
+             insn_bytes = PFX_BYTES + 2;
+             copy_REX_VEX(opc, rex_prefix, vex);
+         }
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         _regs.eflags &= ~EFLAGS_MASK;
+         invoke_stub("",
+@@ -7128,7 +7134,7 @@ x86_emulate(
+         opc[1] = modrm & 0xc7;
+         insn_bytes = PFX_BYTES + 2;
+     simd_0f_to_gpr:
+-        opc[insn_bytes - PFX_BYTES] = 0xc3;
++        place_ret(&opc[insn_bytes - PFX_BYTES]);
+ 
+         generate_exception_if(ea.type != OP_REG, EXC_UD);
+ 
+@@ -7525,7 +7531,7 @@ x86_emulate(
+             vex.w = 0;
+         opc[1] = modrm & 0x38;
+         insn_bytes = PFX_BYTES + 2;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         copy_REX_VEX(opc, rex_prefix, vex);
+         invoke_stub("", "", "+m" (src.val) : "a" (&src.val));
+@@ -7553,7 +7559,7 @@ x86_emulate(
+             evex.w = 0;
+         opc[1] = modrm & 0x38;
+         insn_bytes = EVEX_PFX_BYTES + 2;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         copy_EVEX(opc, evex);
+         invoke_stub("", "", "+m" (src.val) : "a" (&src.val));
+@@ -7748,7 +7754,7 @@ x86_emulate(
+ #endif /* X86EMUL_NO_SIMD */
+ 
+     simd_0f_reg_only:
+-        opc[insn_bytes - PFX_BYTES] = 0xc3;
++        place_ret(&opc[insn_bytes - PFX_BYTES]);
+ 
+         copy_REX_VEX(opc, rex_prefix, vex);
+         invoke_stub("", "", [dummy_out] "=g" (dummy) : [dummy_in] "i" (0) );
+@@ -8073,7 +8079,7 @@ x86_emulate(
+         if ( !mode_64bit() )
+             vex.w = 0;
+         opc[1] = modrm & 0xf8;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         copy_VEX(opc, vex);
+         ea.reg = decode_gpr(&_regs, modrm_rm);
+@@ -8116,7 +8122,7 @@ x86_emulate(
+         if ( !mode_64bit() )
+             vex.w = 0;
+         opc[1] = modrm & 0xc7;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         copy_VEX(opc, vex);
+         invoke_stub("", "", "=a" (dst.val) : [dummy] "i" (0));
+@@ -8146,7 +8152,7 @@ x86_emulate(
+         opc = init_prefixes(stub);
+         opc[0] = b;
+         opc[1] = modrm;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         copy_VEX(opc, vex);
+         _regs.eflags &= ~EFLAGS_MASK;
+@@ -9042,7 +9048,7 @@ x86_emulate(
+         if ( !mode_64bit() )
+             vex.w = 0;
+         opc[1] = modrm & 0xc7;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         copy_REX_VEX(opc, rex_prefix, vex);
+         invoke_stub("", "", "=a" (ea.val) : [dummy] "i" (0));
+@@ -9160,7 +9166,7 @@ x86_emulate(
+             opc[1] &= 0x38;
+         }
+         insn_bytes = PFX_BYTES + 2;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+         if ( vex.opcx == vex_none )
+         {
+             /* Cover for extra prefix byte. */
+@@ -9439,7 +9445,7 @@ x86_emulate(
+         pvex->b = !mode_64bit() || (vex.reg >> 3);
+         opc[1] = 0xc0 | (~vex.reg & 7);
+         pvex->reg = 0xf;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         invoke_stub("", "", "=a" (ea.val) : [dummy] "i" (0));
+         put_stub(stub);
+@@ -9699,7 +9705,7 @@ x86_emulate(
+             evex.w = 0;
+         opc[1] = modrm & 0xf8;
+         insn_bytes = EVEX_PFX_BYTES + 2;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         copy_EVEX(opc, evex);
+         invoke_stub("", "", "=g" (dummy) : "a" (src.val));
+@@ -9798,7 +9804,7 @@ x86_emulate(
+         pvex->b = 1;
+         opc[1] = (modrm_reg & 7) << 3;
+         pvex->reg = 0xf;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         invoke_stub("", "", "=m" (*mmvalp) : "a" (mmvalp));
+ 
+@@ -9868,7 +9874,7 @@ x86_emulate(
+         pvex->b = 1;
+         opc[1] = (modrm_reg & 7) << 3;
+         pvex->reg = 0xf;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         invoke_stub("", "", "+m" (*mmvalp) : "a" (mmvalp));
+ 
+@@ -9924,7 +9930,7 @@ x86_emulate(
+         pevex->b = 1;
+         opc[1] = (modrm_reg & 7) << 3;
+         pevex->RX = 1;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         invoke_stub("", "", "=m" (*mmvalp) : "a" (mmvalp));
+ 
+@@ -9989,7 +9995,7 @@ x86_emulate(
+         pevex->b = 1;
+         opc[1] = (modrm_reg & 7) << 3;
+         pevex->RX = 1;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         invoke_stub("", "", "+m" (*mmvalp) : "a" (mmvalp));
+ 
+@@ -10003,7 +10009,7 @@ x86_emulate(
+         opc[2] = 0x90;
+         /* Use (%rax) as source. */
+         opc[3] = evex.opmsk << 3;
+-        opc[4] = 0xc3;
++        place_ret(&opc[4]);
+ 
+         invoke_stub("", "", "+m" (op_mask) : "a" (&op_mask));
+         put_stub(stub);
+@@ -10097,7 +10103,7 @@ x86_emulate(
+         pevex->b = 1;
+         opc[1] = (modrm_reg & 7) << 3;
+         pevex->RX = 1;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         invoke_stub("", "", "=m" (*mmvalp) : "a" (mmvalp));
+ 
+@@ -10175,7 +10181,7 @@ x86_emulate(
+         opc[2] = 0x90;
+         /* Use (%rax) as source. */
+         opc[3] = evex.opmsk << 3;
+-        opc[4] = 0xc3;
++        place_ret(&opc[4]);
+ 
+         invoke_stub("", "", "+m" (op_mask) : "a" (&op_mask));
+         put_stub(stub);
+@@ -10244,7 +10250,7 @@ x86_emulate(
+         pevex->r = !mode_64bit() || !(state->sib_index & 0x08);
+         pevex->R = !mode_64bit() || !(state->sib_index & 0x10);
+         pevex->RX = 1;
+-        opc[2] = 0xc3;
++        place_ret(&opc[2]);
+ 
+         invoke_stub("", "", "=m" (index) : "a" (&index));
+         put_stub(stub);
+@@ -10422,7 +10428,7 @@ x86_emulate(
+         pvex->reg = 0xf; /* rAX */
+         buf[3] = b;
+         buf[4] = 0x09; /* reg=rCX r/m=(%rCX) */
+-        buf[5] = 0xc3;
++        place_ret(&buf[5]);
+ 
+         src.reg = decode_vex_gpr(vex.reg, &_regs, ctxt);
+         emulate_stub([dst] "=&c" (dst.val), "[dst]" (&src.val), "a" (*src.reg));
+@@ -10458,7 +10464,7 @@ x86_emulate(
+         pvex->reg = 0xf; /* rAX */
+         buf[3] = b;
+         buf[4] = (modrm & 0x38) | 0x01; /* r/m=(%rCX) */
+-        buf[5] = 0xc3;
++        place_ret(&buf[5]);
+ 
+         dst.reg = decode_vex_gpr(vex.reg, &_regs, ctxt);
+         emulate_stub("=&a" (dst.val), "c" (&src.val));
+@@ -10690,7 +10696,7 @@ x86_emulate(
+             evex.w = vex.w = 0;
+         opc[1] = modrm & 0x38;
+         opc[2] = imm1;
+-        opc[3] = 0xc3;
++        place_ret(&opc[3]);
+         if ( vex.opcx == vex_none )
+         {
+             /* Cover for extra prefix byte. */
+@@ -10857,7 +10863,7 @@ x86_emulate(
+             insn_bytes = PFX_BYTES + 3;
+             copy_VEX(opc, vex);
+         }
+-        opc[3] = 0xc3;
++        place_ret(&opc[3]);
+ 
+         /* Latch MXCSR - we may need to restore it below. */
+         invoke_stub("stmxcsr %[mxcsr]", "",
+@@ -11085,7 +11091,7 @@ x86_emulate(
+         }
+         opc[2] = imm1;
+         insn_bytes = PFX_BYTES + 3;
+-        opc[3] = 0xc3;
++        place_ret(&opc[3]);
+         if ( vex.opcx == vex_none )
+         {
+             /* Cover for extra prefix byte. */
+@@ -11240,7 +11246,7 @@ x86_emulate(
+         pxop->reg = 0xf; /* rAX */
+         buf[3] = b;
+         buf[4] = (modrm & 0x38) | 0x01; /* r/m=(%rCX) */
+-        buf[5] = 0xc3;
++        place_ret(&buf[5]);
+ 
+         dst.reg = decode_vex_gpr(vex.reg, &_regs, ctxt);
+         emulate_stub([dst] "=&a" (dst.val), "c" (&src.val));
+@@ -11349,7 +11355,7 @@ x86_emulate(
+         buf[3] = b;
+         buf[4] = 0x09; /* reg=rCX r/m=(%rCX) */
+         *(uint32_t *)(buf + 5) = imm1;
+-        buf[9] = 0xc3;
++        place_ret(&buf[9]);
+ 
+         emulate_stub([dst] "=&c" (dst.val), "[dst]" (&src.val));
+ 
+@@ -11416,12 +11422,12 @@ x86_emulate(
+             BUG();
+         if ( evex_encoded() )
+         {
+-            opc[insn_bytes - EVEX_PFX_BYTES] = 0xc3;
++            place_ret(&opc[insn_bytes - EVEX_PFX_BYTES]);
+             copy_EVEX(opc, evex);
+         }
+         else
+         {
+-            opc[insn_bytes - PFX_BYTES] = 0xc3;
++            place_ret(&opc[insn_bytes - PFX_BYTES]);
+             copy_REX_VEX(opc, rex_prefix, vex);
+         }
+ 

--- a/SOURCES/x86-thunk-Build-Xen-with-Return-Thunks.patch
+++ b/SOURCES/x86-thunk-Build-Xen-with-Return-Thunks.patch
@@ -1,0 +1,379 @@
+From ac050f6517f9fe101bd08b8e0cf7a602076296b7 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Mon, 7 Apr 2025 17:15:17 +0200
+Subject: x86/thunk: Build Xen with Return Thunks
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Indirect Target Selection speculative vulnerability means that indirect
+branches (including RETs) are unsafe when in the first half of a cacheline.
+
+In order to mitigate this, build with return thunks and arrange for
+__x86_return_thunk to be (mis)aligned in the same manner as
+__x86_indirect_thunk_* so the RET instruction is placed in a safe location.
+
+place_ret() needs to conditionally emit JMP __x86_return_thunk instead of RET.
+
+This is part of XSA-469 / CVE-2024-28956
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+
+diff --git a/xen/arch/x86/Kconfig b/xen/arch/x86/Kconfig
+index 366f82fb8587..62f958598d72 100644
+--- a/xen/arch/x86/Kconfig
++++ b/xen/arch/x86/Kconfig
+@@ -34,9 +34,14 @@ config ARCH_DEFCONFIG
+ 	default "arch/x86/configs/x86_64_defconfig"
+ 
+ config CC_HAS_INDIRECT_THUNK
++	# GCC >= 8 or Clang >= 6
+ 	def_bool $(cc-option,-mindirect-branch-register) || \
+ 	         $(cc-option,-mretpoline-external-thunk)
+ 
++config CC_HAS_RETURN_THUNK
++	# GCC >= 8 or Clang >= 15
++	def_bool $(cc-option,-mfunction-return=thunk-extern)
++
+ config HAS_AS_CET_SS
+ 	# binutils >= 2.29 or LLVM >= 6
+ 	def_bool $(as-instr,wrssq %rax$(comma)0;setssbsy)
+diff --git a/xen/arch/x86/Makefile b/xen/arch/x86/Makefile
+index fd73b6d06bcc..276a7dd22767 100644
+--- a/xen/arch/x86/Makefile
++++ b/xen/arch/x86/Makefile
+@@ -42,6 +42,7 @@ obj-$(CONFIG_LIVEPATCH) += livepatch.o
+ obj-y += msi.o
+ obj-y += msr.o
+ obj-$(CONFIG_INDIRECT_THUNK) += indirect-thunk.o
++obj-$(CONFIG_RETURN_THUNK) += indirect-thunk.o
+ obj-$(CONFIG_PV) += ioport_emulate.o
+ obj-y += irq.o
+ obj-$(CONFIG_KEXEC) += machine_kexec.o
+diff --git a/xen/arch/x86/acpi/wakeup_prot.S b/xen/arch/x86/acpi/wakeup_prot.S
+index 3855ff1ddb94..cd4682b9f9c5 100644
+--- a/xen/arch/x86/acpi/wakeup_prot.S
++++ b/xen/arch/x86/acpi/wakeup_prot.S
+@@ -131,7 +131,7 @@ ENTRY(s3_resume)
+         pop     %r12
+         pop     %rbx
+         pop     %rbp
+-        ret
++        RET
+ 
+ .data
+         .align 16
+diff --git a/xen/arch/x86/alternative.c b/xen/arch/x86/alternative.c
+index 8e5f3e63f84c..b80cf6fead44 100644
+--- a/xen/arch/x86/alternative.c
++++ b/xen/arch/x86/alternative.c
+@@ -149,16 +149,45 @@ void init_or_livepatch add_nops(void *insns, unsigned int len)
+     }
+ }
+ 
++void nocall __x86_return_thunk(void);
++
+ /*
+  * Place a return at @ptr.  @ptr must be in the writable alias of a stub.
+  *
++ * When CONFIG_RETURN_THUNK is active, this may be a JMP __x86_return_thunk
++ * instead, depending on the safety of @ptr with respect to Indirect Target
++ * Selection.
++ *
+  * Returns the next position to write into the stub.
+  */
+ void *place_ret(void *ptr)
+ {
++    unsigned long addr = (unsigned long)ptr;
+     uint8_t *p = ptr;
+ 
+-    *p++ = 0xc3;
++    /*
++     * When Return Thunks are used, if a RET would be unsafe at this location
++     * with respect to Indirect Target Selection (i.e. if addr is in the first
++     * half of a cacheline), insert a JMP __x86_return_thunk instead.
++     *
++     * The displacement needs to be relative to the executable alias of the
++     * stub, not to @ptr which is the writeable alias.
++     */
++    if ( IS_ENABLED(CONFIG_RETURN_THUNK) && !(addr & 0x20) )
++    {
++        long stub_va = (this_cpu(stubs.addr) & PAGE_MASK) + (addr & ~PAGE_MASK);
++        long disp = (long)__x86_return_thunk - (stub_va + 5);
++
++        BUG_ON((int32_t)disp != disp);
++
++        *p++ = 0xe9;
++        *(int32_t *)p = disp;
++        p += 4;
++    }
++    else
++    {
++        *p++ = 0xc3;
++    }
+ 
+     return p;
+ }
+diff --git a/xen/arch/x86/arch.mk b/xen/arch/x86/arch.mk
+index 5ad794fff923..79caff7849f0 100644
+--- a/xen/arch/x86/arch.mk
++++ b/xen/arch/x86/arch.mk
+@@ -56,6 +56,9 @@ endif
+ # how to deal with such changes.
+ $(call cc-option-add,CFLAGS-$(CONFIG_LIVEPATCH),CC,-Wa$$(comma)-mx86-used-note=no)
+ 
++# Compile with return thunk support if selected.
++CFLAGS-$(CONFIG_RETURN_THUNK) += -mfunction-return=thunk-extern
++
+ ifdef CONFIG_XEN_IBT
+ # Force -fno-jump-tables to work around
+ #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104816
+diff --git a/xen/arch/x86/bhb-thunk.S b/xen/arch/x86/bhb-thunk.S
+index 05f1043df7d0..472da481dd42 100644
+--- a/xen/arch/x86/bhb-thunk.S
++++ b/xen/arch/x86/bhb-thunk.S
+@@ -23,7 +23,7 @@ ENTRY(clear_bhb_tsx)
+ 0:      .byte 0xc6, 0xf8, 0             /* xabort $0 */
+         int3
+ 1:
+-        ret
++        RET
+ 
+         .size clear_bhb_tsx, . - clear_bhb_tsx
+         .type clear_bhb_tsx, @function
+diff --git a/xen/arch/x86/clear_page.S b/xen/arch/x86/clear_page.S
+index d9d524c79ecd..ea70bd91676e 100644
+--- a/xen/arch/x86/clear_page.S
++++ b/xen/arch/x86/clear_page.S
+@@ -1,5 +1,6 @@
+         .file __FILE__
+ 
++#include <asm/asm_defns.h>
+ #include <asm/page.h>
+ 
+ ENTRY(clear_page_sse2)
+@@ -15,4 +16,4 @@ ENTRY(clear_page_sse2)
+         jnz     0b
+ 
+         sfence
+-        ret
++        RET
+diff --git a/xen/arch/x86/copy_page.S b/xen/arch/x86/copy_page.S
+index 2da81126c5fa..bb79c5fc79db 100644
+--- a/xen/arch/x86/copy_page.S
++++ b/xen/arch/x86/copy_page.S
+@@ -1,5 +1,6 @@
+         .file __FILE__
+ 
++#include <asm/asm_defns.h>
+ #include <asm/page.h>
+ 
+ #define src_reg %rsi
+@@ -40,4 +41,4 @@ ENTRY(copy_page_sse2)
+         movnti  tmp4_reg, 3*WORD_SIZE(dst_reg)
+ 
+         sfence
+-        ret
++        RET
+diff --git a/xen/arch/x86/efi/check.c b/xen/arch/x86/efi/check.c
+index 9e473faad3c9..23ba30abf330 100644
+--- a/xen/arch/x86/efi/check.c
++++ b/xen/arch/x86/efi/check.c
+@@ -3,6 +3,9 @@ int __attribute__((__ms_abi__)) test(int i)
+     return i;
+ }
+ 
++/* In case -mfunction-return is in use. */
++void __x86_return_thunk(void) {};
++
+ /*
+  * Populate an array with "addresses" of relocatable and absolute values.
+  * This is to probe ld for (a) emitting base relocations at all and (b) not
+diff --git a/xen/arch/x86/include/asm/asm-defns.h b/xen/arch/x86/include/asm/asm-defns.h
+index 7e22fcb9c06b..a9ca0d05ec99 100644
+--- a/xen/arch/x86/include/asm/asm-defns.h
++++ b/xen/arch/x86/include/asm/asm-defns.h
+@@ -47,6 +47,12 @@
+     .endif
+ .endm
+ 
++#ifdef CONFIG_RETURN_THUNK
++# define RET jmp __x86_return_thunk
++#else
++# define RET ret
++#endif
++
+ #ifdef CONFIG_XEN_IBT
+ # define ENDBR64 endbr64
+ #else
+diff --git a/xen/arch/x86/indirect-thunk.S b/xen/arch/x86/indirect-thunk.S
+index 20d0e18cd2b0..fd0510f812e3 100644
+--- a/xen/arch/x86/indirect-thunk.S
++++ b/xen/arch/x86/indirect-thunk.S
+@@ -11,6 +11,9 @@
+ 
+ #include <asm/asm_defns.h>
+ 
++
++#ifdef CONFIG_INDIRECT_THUNK
++
+ .macro IND_THUNK_RETPOLINE reg:req
+         call 1f
+         int3
+@@ -60,3 +63,27 @@ ENTRY(__x86_indirect_thunk_\reg)
+ .irp reg, ax, cx, dx, bx, bp, si, di, 8, 9, 10, 11, 12, 13, 14, 15
+         GEN_INDIRECT_THUNK reg=r\reg
+ .endr
++
++#endif /* CONFIG_INDIRECT_THUNK */
++
++#ifdef CONFIG_RETURN_THUNK
++        .section .text.entry.__x86_return_thunk, "ax", @progbits
++
++        /*
++         * The Indirect Target Selection speculative vulnerability means that
++         * indirect branches (including RETs) are unsafe when in the first
++         * half of a cacheline.  Arrange for them to be in the second half.
++         *
++         * Align to 64, then skip 32.
++         */
++        .balign 64
++        .fill 32, 1, 0xcc
++
++ENTRY(__x86_return_thunk)
++        ret
++        int3 /* Halt straight-line speculation */
++
++        .size __x86_return_thunk, . - __x86_return_thunk
++        .type __x86_return_thunk, @function
++
++#endif /* CONFIG_RETURN_THUNK */
+diff --git a/xen/arch/x86/pv/emul-priv-op.c b/xen/arch/x86/pv/emul-priv-op.c
+index 949cec4e16ae..c9f866781c6d 100644
+--- a/xen/arch/x86/pv/emul-priv-op.c
++++ b/xen/arch/x86/pv/emul-priv-op.c
+@@ -143,7 +143,7 @@ static io_emul_stub_t *io_emul_stub_setup(struct priv_op_ctxt *ctxt, u8 opcode,
+     BUILD_BUG_ON(STUB_BUF_SIZE / 2 <
+                  (sizeof(prologue) + sizeof(epilogue) + 10 /* 2x call */ +
+                   MAX(3 /* default stub */, IOEMUL_QUIRK_STUB_BYTES) +
+-                  1 /* ret */));
++                  (IS_ENABLED(CONFIG_RETURN_THUNK) ? 5 : 1) /* ret */));
+     /* Runtime confirmation that we haven't clobbered an adjacent stub. */
+     BUG_ON(STUB_BUF_SIZE / 2 < (p - ctxt->io_emul_stub));
+ 
+diff --git a/xen/arch/x86/pv/gpr_switch.S b/xen/arch/x86/pv/gpr_switch.S
+index e7f5bfcd2d03..d90435be882e 100644
+--- a/xen/arch/x86/pv/gpr_switch.S
++++ b/xen/arch/x86/pv/gpr_switch.S
+@@ -26,7 +26,7 @@ ENTRY(load_guest_gprs)
+         movq  UREGS_r15(%rdi), %r15
+         movq  UREGS_rcx(%rdi), %rcx
+         movq  UREGS_rdi(%rdi), %rdi
+-        ret
++        RET
+ 
+         .size load_guest_gprs, . - load_guest_gprs
+         .type load_guest_gprs, STT_FUNC
+@@ -51,7 +51,7 @@ ENTRY(save_guest_gprs)
+         movq  %rbx, UREGS_rbx(%rdi)
+         movq  %rdx, UREGS_rdx(%rdi)
+         movq  %rcx, UREGS_rcx(%rdi)
+-        ret
++        RET
+ 
+         .size save_guest_gprs, . - save_guest_gprs
+         .type save_guest_gprs, STT_FUNC
+diff --git a/xen/arch/x86/spec_ctrl.c b/xen/arch/x86/spec_ctrl.c
+index fcfa95482e56..bbd419a4857a 100644
+--- a/xen/arch/x86/spec_ctrl.c
++++ b/xen/arch/x86/spec_ctrl.c
+@@ -581,6 +581,9 @@ static void __init print_details(enum ind_thunk thunk)
+ #ifdef CONFIG_INDIRECT_THUNK
+                " INDIRECT_THUNK"
+ #endif
++#ifdef CONFIG_RETURN_THUNK
++               " RETURN_THUNK"
++#endif
+ #ifdef CONFIG_SHADOW_PAGING
+                " SHADOW_PAGING"
+ #endif
+diff --git a/xen/arch/x86/x86_64/compat/entry.S b/xen/arch/x86/x86_64/compat/entry.S
+index ff6fa2233174..eea838914a79 100644
+--- a/xen/arch/x86/x86_64/compat/entry.S
++++ b/xen/arch/x86/x86_64/compat/entry.S
+@@ -182,7 +182,7 @@ FUNC(cr4_pv32_restore)
+         mov   %rax, %cr4
+         mov   %rax, (%rdx)
+         pop   %rdx
+-        ret
++        RET
+ 0:
+ #ifndef NDEBUG
+         /* Check that _all_ of the bits intended to be set actually are. */
+@@ -201,7 +201,7 @@ FUNC(cr4_pv32_restore)
+ #endif
+         pop   %rdx
+         xor   %eax, %eax
+-        ret
++        RET
+ END(cr4_pv32_restore)
+ 
+ FUNC(compat_syscall)
+@@ -332,7 +332,7 @@ __UNLIKELY_END(compat_bounce_null_selector)
+         xor   %eax, %eax
+         mov   %ax,  TRAPBOUNCE_cs(%rdx)
+         mov   %al,  TRAPBOUNCE_flags(%rdx)
+-        ret
++        RET
+ 
+ .section .fixup,"ax"
+ .Lfx13:
+diff --git a/xen/arch/x86/x86_64/entry.S b/xen/arch/x86/x86_64/entry.S
+index f8b8a8bb50e9..a803d971c946 100644
+--- a/xen/arch/x86/x86_64/entry.S
++++ b/xen/arch/x86/x86_64/entry.S
+@@ -599,7 +599,7 @@ __UNLIKELY_END(create_bounce_frame_bad_bounce_ip)
+         xor   %eax, %eax
+         mov   %rax, TRAPBOUNCE_eip(%rdx)
+         mov   %al,  TRAPBOUNCE_flags(%rdx)
+-        ret
++        RET
+ 
+         .pushsection .fixup, "ax", @progbits
+         # Numeric tags below represent the intended overall %rsi adjustment.
+diff --git a/xen/arch/x86/xen.lds.S b/xen/arch/x86/xen.lds.S
+index 8930e14fc40e..b66e708ebf69 100644
+--- a/xen/arch/x86/xen.lds.S
++++ b/xen/arch/x86/xen.lds.S
+@@ -86,6 +86,7 @@ SECTIONS
+        . = ALIGN(PAGE_SIZE);
+        _stextentry = .;
+        *(.text.entry)
++       *(.text.entry.*)
+        . = ALIGN(PAGE_SIZE);
+        _etextentry = .;
+ 
+diff --git a/xen/common/Kconfig b/xen/common/Kconfig
+index cd0971877b60..af3cbc5816de 100644
+--- a/xen/common/Kconfig
++++ b/xen/common/Kconfig
+@@ -124,6 +124,17 @@ config INDIRECT_THUNK
+ 	  When enabled, indirect branches are implemented using a new construct
+ 	  called "retpoline" that prevents speculation.
+ 
++config RETURN_THUNK
++	bool "Out-of-line Returns"
++	depends on CC_HAS_RETURN_THUNK
++	default INDIRECT_THUNK
++	help
++	  Compile Xen with out-of-line returns.
++
++	  This allows Xen to mitigate a variety of speculative vulnerabilities
++	  by choosing a hardware-dependent instruction sequence to implement
++	  function returns safely.
++
+ config SPECULATIVE_HARDEN_ARRAY
+ 	bool "Speculative Array Hardening"
+ 	default y

--- a/SOURCES/x86-thunk-Mis-align-__x86_indirect_thunk_-to-mitigat.patch
+++ b/SOURCES/x86-thunk-Mis-align-__x86_indirect_thunk_-to-mitigat.patch
@@ -1,0 +1,37 @@
+From 8f1efbacc2cdc24da7ae258dfd98a026f9a27d6f Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Mon, 7 Apr 2025 17:15:50 +0200
+Subject: x86/thunk: (Mis)align __x86_indirect_thunk_* to mitigate ITS
+
+The Indirect Target Selection speculative vulnerability means that indirect
+branches (including RETs) are unsafe when in the first half of a cacheline.
+
+Arrange for __x86_indirect_thunk_* to always be in the second half.
+
+This is part of XSA-469 / CVE-2024-28956
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+diff --git a/xen/arch/x86/indirect-thunk.S b/xen/arch/x86/indirect-thunk.S
+index de6aef606832..e7ef104d3bd3 100644
+--- a/xen/arch/x86/indirect-thunk.S
++++ b/xen/arch/x86/indirect-thunk.S
+@@ -35,6 +35,16 @@
+ .macro GEN_INDIRECT_THUNK reg:req
+         .section .text.__x86_indirect_thunk_\reg, "ax", @progbits
+ 
++        /*
++         * The Indirect Target Selection speculative vulnerability means that
++         * indirect branches (including RETs) are unsafe when in the first
++         * half of a cacheline.  Arrange for them to be in the second half.
++         *
++         * Align to 64, then skip 32.
++         */
++        .balign 64
++        .fill 32, 1, 0xcc
++
+ ENTRY(__x86_indirect_thunk_\reg)
+         ALTERNATIVE_2 __stringify(IND_THUNK_RETPOLINE \reg),              \
+         __stringify(IND_THUNK_LFENCE \reg), X86_FEATURE_IND_THUNK_LFENCE, \

--- a/SOURCES/x86-thunk-Mis-align-the-RETs-in-clear_bhb_loops-to-m.patch
+++ b/SOURCES/x86-thunk-Mis-align-the-RETs-in-clear_bhb_loops-to-m.patch
@@ -1,0 +1,69 @@
+From 864498b17ccfb997b9af5aeca91d171affc4157d Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Mon, 5 May 2025 14:27:01 +0100
+Subject: x86/thunk: (Mis)align the RETs in clear_bhb_loops() to mitigate ITS
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Indirect Target Selection speculative vulnerability means that indirect
+branches (including RETs) are unsafe when in the first half of a cacheline.
+
+clear_bhb_loops() has a precise layout of branches.  The alignment for
+performance cause the RETs to always be in an unsafe position, and converting
+those to return thunks changes the branching pattern.  While such a conversion
+is believed to be safe, clear_bhb_loops() is also a performance-relevant
+fastpath, so (mis)align the RETs to be in a safe position.
+
+No functional change.
+
+This is part of XSA-469 / CVE-2024-28956
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+
+diff --git a/xen/arch/x86/bhb-thunk.S b/xen/arch/x86/bhb-thunk.S
+index 7e866784f784..05f1043df7d0 100644
+--- a/xen/arch/x86/bhb-thunk.S
++++ b/xen/arch/x86/bhb-thunk.S
+@@ -52,7 +52,12 @@ ENTRY(clear_bhb_tsx)
+  *   ret
+  *
+  * The CALL/RETs are necessary to prevent the Loop Stream Detector from
+- * interfering.  The alignment is for performance and not safety.
++ * interfering.
++ *
++ * The .balign's are for performance, but they cause the RETs to be in unsafe
++ * positions with respect to Indirect Target Selection.  The .skips are to
++ * move the RETs into ITS-safe positions, rather than using the slowpath
++ * through __x86_return_thunk.
+  *
+  * The "short" sequence (5 and 5) is for CPUs prior to Alder Lake / Sapphire
+  * Rapids (i.e. Cores prior to Golden Cove and/or Gracemont).
+@@ -68,12 +73,14 @@ ENTRY(clear_bhb_loops)
+         jmp     5f
+         int3
+ 
+-        .align 64
++        .balign 64
++        .skip   32 - (.Lr1 - 1f), 0xcc
+ 1:      call    2f
+-        ret
++.Lr1:   ret
+         int3
+ 
+-        .align 64
++        .balign 64
++        .skip   32 - 18 /* (.Lr2 - 2f) but Clang IAS doesn't like this */, 0xcc
+ 2:      ALTERNATIVE "mov $5, %eax", "mov $7, %eax", X86_SPEC_BHB_LOOPS_LONG
+ 
+ 3:      jmp     4f
+@@ -85,7 +92,7 @@ ENTRY(clear_bhb_loops)
+         sub     $1, %ecx
+         jnz     1b
+ 
+-        ret
++.Lr2:   ret
+ 5:
+         /*
+          * The Intel sequence has an LFENCE here.  The purpose is to ensure

--- a/SOURCES/xen-spec-ctrl-utility.patch
+++ b/SOURCES/xen-spec-ctrl-utility.patch
@@ -107,10 +107,10 @@ index 000000000000..d46778eca989
 +    return 0;
 +}
 diff --git a/xen/arch/x86/cpu-policy.c b/xen/arch/x86/cpu-policy.c
-index 68a70e08decf..6c0d3919b62e 100644
+index b594deee39fd..c07a1268ad08 100644
 --- a/xen/arch/x86/cpu-policy.c
 +++ b/xen/arch/x86/cpu-policy.c
-@@ -17,26 +17,26 @@
+@@ -18,26 +18,26 @@
  #include <asm/xstate.h>
  
  struct cpu_policy __read_mostly       raw_cpu_policy;
@@ -147,7 +147,7 @@ index 68a70e08decf..6c0d3919b62e 100644
      INIT_HVM_HAP_DEF_FEATURES;
  static const uint32_t deep_features[] = INIT_DEEP_FEATURES;
  
-@@ -373,7 +373,7 @@ void calculate_raw_cpu_policy(void)
+@@ -374,7 +374,7 @@ void calculate_raw_cpu_policy(void)
      /* Was already added by probe_cpuid_faulting() */
  }
  
@@ -156,7 +156,7 @@ index 68a70e08decf..6c0d3919b62e 100644
  {
      struct cpu_policy *p = &host_cpu_policy;
      unsigned int max_extd_leaf;
-@@ -431,7 +431,7 @@ static void __init calculate_host_policy(void)
+@@ -432,7 +432,7 @@ static void __init calculate_host_policy(void)
   * - Some incoming VMs have a larger-than-necessary feat max_subleaf.
   * - Some VMs we'd like to synthesise leaves not present on the host.
   */
@@ -165,7 +165,7 @@ index 68a70e08decf..6c0d3919b62e 100644
  {
      p->basic.max_leaf       = ARRAY_SIZE(p->basic.raw) - 1;
      p->feat.max_subleaf     = ARRAY_SIZE(p->feat.raw) - 1;
-@@ -439,14 +439,14 @@ static void __init guest_common_max_leaves(struct cpu_policy *p)
+@@ -440,14 +440,14 @@ static void __init guest_common_max_leaves(struct cpu_policy *p)
  }
  
  /* Guest default policies inherit the host max leaf/subleaf settings. */
@@ -182,7 +182,7 @@ index 68a70e08decf..6c0d3919b62e 100644
  {
      if ( boot_cpu_data.x86_vendor == X86_VENDOR_INTEL )
      {
-@@ -522,7 +522,7 @@ static void __init guest_common_max_feature_adjustments(uint32_t *fs)
+@@ -523,7 +523,7 @@ static void __init guest_common_max_feature_adjustments(uint32_t *fs)
          __set_bit(X86_FEATURE_RTM_ALWAYS_ABORT, fs);
  }
  
@@ -191,7 +191,7 @@ index 68a70e08decf..6c0d3919b62e 100644
  {
      if ( boot_cpu_data.x86_vendor == X86_VENDOR_INTEL )
      {
-@@ -602,7 +602,7 @@ static void __init guest_common_default_feature_adjustments(uint32_t *fs)
+@@ -603,7 +603,7 @@ static void __init guest_common_default_feature_adjustments(uint32_t *fs)
      }
  }
  
@@ -200,7 +200,7 @@ index 68a70e08decf..6c0d3919b62e 100644
  {
      /* Unconditionally claim to be able to set the hypervisor bit. */
      __set_bit(X86_FEATURE_HYPERVISOR, fs);
-@@ -626,7 +626,7 @@ static void __init guest_common_feature_adjustments(uint32_t *fs)
+@@ -627,7 +627,7 @@ static void __init guest_common_feature_adjustments(uint32_t *fs)
          __set_bit(X86_FEATURE_IBPB, fs);
  }
  
@@ -209,7 +209,7 @@ index 68a70e08decf..6c0d3919b62e 100644
  {
      struct cpu_policy *p = &pv_max_cpu_policy;
      uint32_t fs[FSCAPINTS];
-@@ -707,7 +707,7 @@ static void __init calculate_pv_def_policy(void)
+@@ -728,7 +728,7 @@ static void __init calculate_pv_def_policy(void)
      recalculate_xstate(p);
  }
  
@@ -218,7 +218,7 @@ index 68a70e08decf..6c0d3919b62e 100644
  {
      struct cpu_policy *p = &hvm_max_cpu_policy;
      uint32_t fs[FSCAPINTS];
-@@ -854,7 +854,7 @@ static void __init calculate_hvm_def_policy(void)
+@@ -875,7 +875,7 @@ static void __init calculate_hvm_def_policy(void)
      recalculate_xstate(p);
  }
  
@@ -228,7 +228,7 @@ index 68a70e08decf..6c0d3919b62e 100644
      calculate_raw_cpu_policy();
      calculate_host_policy();
 diff --git a/xen/arch/x86/cpu/amd.c b/xen/arch/x86/cpu/amd.c
-index 2838725bab98..1aaf1625a474 100644
+index 31f785a446da..4a17fbe5a073 100644
 --- a/xen/arch/x86/cpu/amd.c
 +++ b/xen/arch/x86/cpu/amd.c
 @@ -52,7 +52,7 @@ boolean_param("allow_unsafe", opt_allow_unsafe);
@@ -385,12 +385,12 @@ index 3752861f5bad..90797d5ee6eb 100644
  #define SMT_LEVEL       0
  
 diff --git a/xen/arch/x86/include/asm/processor.h b/xen/arch/x86/include/asm/processor.h
-index 7925e6b911f2..952debf67949 100644
+index ad17f4c8b1a5..6a9339a72f12 100644
 --- a/xen/arch/x86/include/asm/processor.h
 +++ b/xen/arch/x86/include/asm/processor.h
-@@ -593,6 +593,8 @@ void tsx_init(void);
- void update_mcu_opt_ctrl(void);
- void set_in_mcu_opt_ctrl(uint32_t mask, uint32_t val);
+@@ -596,6 +596,8 @@ void set_in_mcu_opt_ctrl(uint32_t mask, uint32_t val);
+ void update_pb_opt_ctrl(void);
+ void set_in_pb_opt_ctrl(uint32_t mask, uint32_t val);
  
 +int sysctl_update_spec_ctrl_cpuid(void);
 +

--- a/SOURCES/xenguest.patch
+++ b/SOURCES/xenguest.patch
@@ -793,10 +793,10 @@ index 000000000000..c45f59e52b9c
 + */
 diff --git a/tools/xenguest/xenguest_stubs.c b/tools/xenguest/xenguest_stubs.c
 new file mode 100644
-index 000000000000..3ff6ddbb84d2
+index 000000000000..2a614ac4c426
 --- /dev/null
 +++ b/tools/xenguest/xenguest_stubs.c
-@@ -0,0 +1,1816 @@
+@@ -0,0 +1,1825 @@
 +/*
 + * Copyright (C) 2006-2009 Citrix Systems Inc.
 + *
@@ -884,6 +884,7 @@ index 000000000000..3ff6ddbb84d2
 +    unsigned cores_per_socket;
 +    unsigned x87_fip_width;
 +    int64_t timeoffset;
++    uint64_t mmio_size;
 +};
 +
 +char *xenstore_getsv(const char *fmt, va_list ap)
@@ -1261,6 +1262,7 @@ index 000000000000..3ff6ddbb84d2
 +        sscanf(tmp, "%" PRId64, &f->timeoffset);
 +        free(tmp);
 +    }
++    f->mmio_size = xenstore_get("platform/mmio_hole_size");
 +
 +    xg_info("Domain Properties: Type %s, hap %u\n",
 +            (f->dominfo.flags & XEN_DOMINF_hvm_guest) ? "HVM" : "PV",
@@ -1273,8 +1275,8 @@ index 000000000000..3ff6ddbb84d2
 +            f->nx, f->pae, f->cores_per_socket, f->x87_fip_width, f->nested_virt);
 +    xg_info("apic: %d acpi: %d acpi_s4: %d acpi_s3: %d tsc_mode: %d hpet: %d\n",
 +            f->apic, f->acpi, f->acpi_s4, f->acpi_s3, f->tsc_mode, f->hpet);
-+    xg_info("nomigrate %d, timeoffset %" PRId64 "\n",
-+            f->nomigrate, f->timeoffset);
++    xg_info("nomigrate %d, timeoffset %" PRId64 " mmio_hole_size %#" PRIx64 "\n",
++            f->nomigrate, f->timeoffset, f->mmio_size);
 +    xg_info("viridian: %d, time_ref_count: %d, reference_tsc: %d "
 +            "hcall_remote_tlb_flush: %d apic_assist: %d "
 +            "crash_ctl: %d stimer: %d hcall_ipi: %d\n",
@@ -2000,7 +2002,7 @@ index 000000000000..3ff6ddbb84d2
 +#define VRAM_RESERVED_SIZE 0x1000000lu
 +
 +int hvm_build_setup_mem(struct xc_dom_image *dom, uint64_t max_mem_mib,
-+                        uint64_t max_start_mib)
++                        uint64_t max_start_mib, uint64_t min_mmio_hole)
 +{
 +    uint64_t lowmem_end, highmem_start, highmem_end, mmio_start, mmio_size;
 +    uint64_t mmio_total = HVM_BELOW_4G_MMIO_LENGTH;
@@ -2071,7 +2073,11 @@ index 000000000000..3ff6ddbb84d2
 +
 +    lowmem_end  = max_mem_mib << 20;
 +    highmem_end = highmem_start = 1ull << 32;
-+    mmio_size   = HVM_BELOW_4G_MMIO_LENGTH;
++    /*
++     * Use the externally provide size as a minimum boundary, expand it if
++     * necessary for correct guest operation based on assigned devices.
++     */
++    mmio_size   = max_t(uint64_t, HVM_BELOW_4G_MMIO_LENGTH, min_mmio_hole);
 +
 +    if ( opt_vgpu )
 +    {
@@ -2080,9 +2086,11 @@ index 000000000000..3ff6ddbb84d2
 +         * as the existing NVIDIA drivers are unable to handle
 +         * 64-bit BARs properly.
 +         */
-+        xg_info("NVIDIA vGPU plugged in. Add extra 0x%lx to MMIO hole\n", mmio_size);
-+        mmio_total += mmio_size;
-+        mmio_size <<= 1;
++        xg_info("NVIDIA vGPU plugged in. Add extra 0x%llx to MMIO hole\n",
++                HVM_BELOW_4G_MMIO_LENGTH);
++        mmio_total += HVM_BELOW_4G_MMIO_LENGTH;
++        if ( mmio_size < HVM_BELOW_4G_MMIO_LENGTH * 2 )
++            mmio_size = HVM_BELOW_4G_MMIO_LENGTH * 2;
 +    }
 +
 +    if ( allow_memory_relocate )
@@ -2406,7 +2414,8 @@ index 000000000000..3ff6ddbb84d2
 +    }
 +    else /* HVM */
 +    {
-+        r = hvm_build_setup_mem(dom, mem_max_mib, mem_start_mib);
++        r = hvm_build_setup_mem(dom, mem_max_mib, mem_start_mib,
++                                f.mmio_size);
 +        if ( r )
 +            failwith_oss_xc("hvm_build_setup_mem");
 +    }

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -1,6 +1,6 @@
-%global package_speccommit 393fb8e26ab536d44a40679f0436292e994b9008
+%global package_speccommit 3941a9ecb541a048d050651817cb40327b50fa2c
 %global usver 4.17.5
-%global xsver 10
+%global xsver 13
 %global xsrel %{xsver}%{?xscount}%{?xshash}
 # -*- rpm-spec -*-
 
@@ -9,7 +9,7 @@
 
 # Hypervisor release.  Should match the tag in the repository and would be in
 # the Release field if it weren't for the %%{xsrel} automagic.
-%global hv_rel 10
+%global hv_rel 13
 
 # Full hash from the HEAD commit of this repo during processing, usually
 # provided by the environment.  Default to ??? if not set.
@@ -179,87 +179,101 @@ Patch134: backport-848b6bc8c9f3.patch
 Patch135: backport-3fc44151d83d.patch
 Patch136: backport-a2bbb140be9d.patch
 Patch137: backport-b953a99da98d.patch
-Patch138: backport-1191ce954f64.patch
-Patch139: backport-446a90345c89.patch
-Patch140: backport-db6daa9bf411.patch
-Patch141: backport-7ab695198123.patch
-Patch142: backport-819c3cb186a8.patch
-Patch143: backport-c11772277fe5.patch
-Patch144: 0006-x86-vpt-fix-injection-to-remote-vCPU.patch
-Patch145: quirk-hp-gen8-rmrr.patch
-Patch146: quirk-pci-phantom-function-devices.patch
-Patch147: 0001-x86-hpet-Pre-cleanup.patch
-Patch148: 0002-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch
-Patch149: 0003-x86-hpet-Post-cleanup.patch
-Patch150: 0002-libxc-retry-shadow-ops-if-EBUSY-is-returned.patch
-Patch151: avoid-gnt-unmap-tlb-flush-if-not-accessed.patch
-Patch152: 0001-x86-time-Don-t-use-EFI-s-GetTime-call.patch
-Patch153: 0001-efi-Workaround-page-fault-during-runtime-service.patch
-Patch154: 0001-x86-HVM-Avoid-cache-flush-operations-during-hvm_load.patch
-Patch155: 0001-libxl-Don-t-insert-PCI-device-into-xenstore-for-HVM-.patch
-Patch156: livepatch-ignore-duplicate-new.patch
-Patch157: 0001-lib-Add-a-generic-implementation-of-current_text_add.patch
-Patch158: 0002-sched-Remove-dependency-on-__LINE__-for-release-buil.patch
-Patch159: pygrub-Ignore-GRUB2-if-statements.patch
-Patch160: libfsimage-Add-support-for-btrfs.patch
-Patch161: quiet-broke-irq-affinity.patch
-Patch162: xen-hide-AVX512-on-SKX-by-default.patch
-Patch163: 0001-common-page_alloc-don-t-idle-scrub-before-microcode-.patch
-Patch164: vpci-drop-const.patch
-Patch165: pci-cache-memory-decode-bit.patch
-Patch166: pci-cache-msi-x-enabled-bit.patch
-Patch167: xen-tweak-cmdline-defaults.patch
-Patch168: xen-tweak-debug-overhead.patch
-Patch169: tweak-iommu-policy.patch
-Patch170: tweak-sc-policy.patch
-Patch171: disable-core-parking.patch
-Patch172: remove-info-leak.patch
-Patch173: 0001-Allocate-space-in-structs-pre-emptively-to-increase-.patch
-Patch174: 0001-x86-mm-partially-revert-37201c62-make-logdirty-and-i.patch
-Patch175: hitachi-driver-domain-ssid.patch
-Patch176: install_targets_for_test_x86_emulator.patch
-Patch177: xen-define-offsets-for-kdump.patch
-Patch178: xen-scheduler-auto-privdom-weight.patch
-Patch179: xen-hvm-disable-tsc-ramping.patch
-Patch180: xen-default-cpufreq-governor-to-performance-on-intel.patch
-Patch181: i8259-timers-pick-online-vcpu.patch
-Patch182: revert-ca2eee92df44.patch
-Patch183: libxc-cpuid-cores_per_socket.patch
-Patch184: libxc-cpu-clear-deps.patch
-Patch185: libxc-cpu-policies.patch
-Patch186: max-featureset-compat.patch
-Patch187: pygrub-add-disk-as-extra-group.patch
-Patch188: pygrub-add-default-and-extra-args.patch
-Patch189: pygrub-always-boot-default.patch
-Patch190: pygrub-friendly-no-fs.patch
-Patch191: pygrub-default-xenmobile-kernel.patch
-Patch192: pygrub-blacklist-support.patch
-Patch193: oem-bios-xensource.patch
-Patch194: misc-log-guest-consoles.patch
-Patch195: mixed-domain-runstates.patch
-Patch196: xenguest.patch
-Patch197: xen-vmdebug.patch
-Patch198: oxenstore-censor-sensitive-data.patch
-Patch199: oxenstore-large-packets.patch
-Patch200: nvidia-vga.patch
-Patch201: hvmloader-disable-pci-option-rom-loading.patch
-Patch202: xen-force-software-vmcs-shadow.patch
-Patch203: 0001-x86-vvmx-add-initial-PV-EPT-support-in-L0.patch
-Patch204: use-msr-ll-instead-of-vmcs-efer.patch
-Patch205: revert-4a7e71aa0851-partial.patch
-Patch206: add-pv-iommu-headers.patch
-Patch207: add-pv-iommu-local-domain-ops.patch
-Patch208: add-pv-iommu-foreign-support.patch
-Patch209: upstream-pv-iommu-tools.patch
-Patch210: Add-PV-IOMMU-elf-note.patch
-Patch211: allow-rombios-pci-config-on-any-host-bridge.patch
-Patch212: gvt-g-hvmloader+rombios.patch
-Patch213: xen-spec-ctrl-utility.patch
-Patch214: vtpm-ppi-acpi-dsm.patch
+Patch138: backport-dd05d265b8ab.patch
+Patch139: backport-1191ce954f64.patch
+Patch140: backport-446a90345c89.patch
+Patch141: backport-db6daa9bf411.patch
+Patch142: backport-7ab695198123.patch
+Patch143: backport-819c3cb186a8.patch
+Patch144: backport-c11772277fe5.patch
+Patch145: backport-c989ff614f6b.patch
+Patch146: backport-8c12e47a5d3b.patch
+Patch147: backport-b28b590d4a23.patch
+Patch148: backport-9a474fcceccf.patch
+Patch149: backport-4aae4452efee.patch
+Patch150: backport-d444763f8ca5.patch
+Patch151: x86-alternative-Support-replacements-when-a-feature-.patch
+Patch152: x86-guest-Remove-use-of-the-Xen-hypercall_page.patch
+Patch153: x86-thunk-Mis-align-__x86_indirect_thunk_-to-mitigat.patch
+Patch154: x86-thunk-Mis-align-the-RETs-in-clear_bhb_loops-to-m.patch
+Patch155: x86-stubs-Introduce-place_ret-to-abstract-away-raw-0.patch
+Patch156: x86-thunk-Build-Xen-with-Return-Thunks.patch
+Patch157: x86-spec-ctrl-Synthesise-ITS_NO-to-guests-on-unaffec.patch
+Patch158: x86-spec-ctrl-Intel-PB-OPT.patch
+Patch159: 0006-x86-vpt-fix-injection-to-remote-vCPU.patch
+Patch160: quirk-hp-gen8-rmrr.patch
+Patch161: quirk-pci-phantom-function-devices.patch
+Patch162: 0001-x86-hpet-Pre-cleanup.patch
+Patch163: 0002-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch
+Patch164: 0003-x86-hpet-Post-cleanup.patch
+Patch165: 0002-libxc-retry-shadow-ops-if-EBUSY-is-returned.patch
+Patch166: avoid-gnt-unmap-tlb-flush-if-not-accessed.patch
+Patch167: 0001-x86-time-Don-t-use-EFI-s-GetTime-call.patch
+Patch168: 0001-efi-Workaround-page-fault-during-runtime-service.patch
+Patch169: 0001-x86-HVM-Avoid-cache-flush-operations-during-hvm_load.patch
+Patch170: 0001-libxl-Don-t-insert-PCI-device-into-xenstore-for-HVM-.patch
+Patch171: livepatch-ignore-duplicate-new.patch
+Patch172: 0001-lib-Add-a-generic-implementation-of-current_text_add.patch
+Patch173: 0002-sched-Remove-dependency-on-__LINE__-for-release-buil.patch
+Patch174: pygrub-Ignore-GRUB2-if-statements.patch
+Patch175: libfsimage-Add-support-for-btrfs.patch
+Patch176: quiet-broke-irq-affinity.patch
+Patch177: xen-hide-AVX512-on-SKX-by-default.patch
+Patch178: 0001-common-page_alloc-don-t-idle-scrub-before-microcode-.patch
+Patch179: vpci-drop-const.patch
+Patch180: pci-cache-memory-decode-bit.patch
+Patch181: pci-cache-msi-x-enabled-bit.patch
+Patch182: xen-tweak-cmdline-defaults.patch
+Patch183: xen-tweak-debug-overhead.patch
+Patch184: tweak-iommu-policy.patch
+Patch185: tweak-sc-policy.patch
+Patch186: disable-core-parking.patch
+Patch187: remove-info-leak.patch
+Patch188: 0001-Allocate-space-in-structs-pre-emptively-to-increase-.patch
+Patch189: 0001-x86-mm-partially-revert-37201c62-make-logdirty-and-i.patch
+Patch190: hitachi-driver-domain-ssid.patch
+Patch191: install_targets_for_test_x86_emulator.patch
+Patch192: xen-define-offsets-for-kdump.patch
+Patch193: xen-scheduler-auto-privdom-weight.patch
+Patch194: xen-hvm-disable-tsc-ramping.patch
+Patch195: xen-default-cpufreq-governor-to-performance-on-intel.patch
+Patch196: i8259-timers-pick-online-vcpu.patch
+Patch197: revert-ca2eee92df44.patch
+Patch198: libxc-cpuid-cores_per_socket.patch
+Patch199: libxc-cpu-clear-deps.patch
+Patch200: libxc-cpu-policies.patch
+Patch201: max-featureset-compat.patch
+Patch202: pygrub-add-disk-as-extra-group.patch
+Patch203: pygrub-add-default-and-extra-args.patch
+Patch204: pygrub-always-boot-default.patch
+Patch205: pygrub-friendly-no-fs.patch
+Patch206: pygrub-default-xenmobile-kernel.patch
+Patch207: pygrub-blacklist-support.patch
+Patch208: oem-bios-xensource.patch
+Patch209: misc-log-guest-consoles.patch
+Patch210: mixed-domain-runstates.patch
+Patch211: xenguest.patch
+Patch212: xen-vmdebug.patch
+Patch213: oxenstore-censor-sensitive-data.patch
+Patch214: oxenstore-large-packets.patch
+Patch215: nvidia-vga.patch
+Patch216: hvmloader-disable-pci-option-rom-loading.patch
+Patch217: xen-force-software-vmcs-shadow.patch
+Patch218: 0001-x86-vvmx-add-initial-PV-EPT-support-in-L0.patch
+Patch219: use-msr-ll-instead-of-vmcs-efer.patch
+Patch220: revert-4a7e71aa0851-partial.patch
+Patch221: add-pv-iommu-headers.patch
+Patch222: add-pv-iommu-local-domain-ops.patch
+Patch223: add-pv-iommu-foreign-support.patch
+Patch224: upstream-pv-iommu-tools.patch
+Patch225: Add-PV-IOMMU-elf-note.patch
+Patch226: allow-rombios-pci-config-on-any-host-bridge.patch
+Patch227: gvt-g-hvmloader+rombios.patch
+Patch228: xen-spec-ctrl-utility.patch
+Patch229: vtpm-ppi-acpi-dsm.patch
 
 # XCP-ng patches
 Patch1000: 0001-xenguest-activate-nested-virt-when-requested.patch
-Patch1001: xen-4.17.5-x86-intel-Fix-PERF_GLOBAL-fixup-when-virtualised.patch
 
 ExclusiveArch: x86_64
 
@@ -1105,6 +1119,19 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Mon May 12 2025 Samuel Verschelde <stormi-xcp@ylix.fr> - 4.17.5-13.1
+- Sync with 4.17.5-13
+- Remove xen-4.17.5-x86-intel-Fix-PERF_GLOBAL-fixup-when-virtualised.patch included in XS
+- *** Upstream changelog ***
+  * Thu May  8 2025 Andrew Cooper <andrew.cooper3@citrix.com> - 4.17.5-13
+  - Fix for XSA-469 CVE-2024-28956
+  * Mon Apr 28 2025 Andrew Cooper <andrew.cooper3@citrix.com> - 4.17.5-12
+  - Work around Ice Lake erratum ICX143, which manifests as a hang on boot
+  - Fix crash on boot when perf counters are unavailable
+  * Wed Mar 26 2025 Roger Pau Monné <roger.pau@citrix.com> - 4.17.5-11
+  - Add xenguest support for the platform:mmio_hole_size attribute
+  - Identify which domain watchdog fired
+
 * Wed May 07 2025 Thierry Escande <thierry.escande@vates.tech> - 4.17.5-10.1
 - Sync with 4.17.5-10
 - Remove xsa467.patch now provided by XS package


### PR DESCRIPTION
As this update will be fast-tracked, built against the current `v8.3-updates` tag, without everything that is currently in testing, I need the Hypervisor team to evaluate whether we can update Xen alone. You need to compare with the currently released Xen in `updates`, which is `xen-4.17.5-4.2.xcpng8.3`.

One possible issue with what I see in the changelog, related to ocaml bindings and/or oxenstored: `- Fix Ocaml rpath setting`