### PR TITLE
hvmloader: Workaround uncached grant-table on AMD cpus

### DIFF
--- a/SOURCES/0001-x86-hvmloader-select-xen-platform-pci-MMIO-BAR-UC-or.patch
+++ b/SOURCES/0001-x86-hvmloader-select-xen-platform-pci-MMIO-BAR-UC-or.patch
@@ -1,0 +1,364 @@
+From 1e94d5f3a95bc918422ea597e98aa158d3b95ac4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Roger=20Pau=20Monn=C3=A9?= <roger.pau@citrix.com>
+Date: Fri, 30 May 2025 13:54:08 +0200
+Subject: [PATCH] x86/hvmloader: select xen platform pci MMIO BAR UC or WB MTRR
+ cache attribute
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Backport notes:
+- fix offsets
+- move added lines of the CHANGELOG.md
+Backported-by: Anthoine Bourgeois <anthoine.bourgeois@vates.tech>
+
+Original commitlog:
+The Xen platform PCI device (vendor ID 0x5853) exposed to x86 HVM guests
+doesn't have the functionality of a traditional PCI device.  The exposed
+MMIO BAR is used by some guests (including Linux) as a safe place to map
+foreign memory, including the grant table itself.
+
+Traditionally BARs from devices have the uncacheable (UC) cache attribute
+from the MTRR, to ensure correct functionality of such devices.  hvmloader
+mimics this behavior and sets the MTRR attributes of both the low and high
+PCI MMIO windows (where BARs of PCI devices reside) as UC in MTRR.
+
+This however causes performance issues for users of the Xen platform PCI
+device BAR, as for the purposes of mapping remote memory there's no need to
+use the UC attribute.  On Intel systems this is worked around by using
+iPAT, that allows the hypervisor to force the effective cache attribute of
+a p2m entry regardless of the guest PAT value.  AMD however doesn't have an
+equivalent of iPAT, and guest PAT values are always considered.
+
+Linux commit:
+
+41925b105e34 xen: replace xen_remap() with memremap()
+
+Attempted to mitigate this by forcing mappings of the grant-table to use
+the write-back (WB) cache attribute.  However Linux memremap() takes MTRRs
+into account to calculate which PAT type to use, and seeing the MTRR cache
+attribute for the region being UC the PAT also ends up as UC, regardless of
+the caller having requested WB.
+
+As a workaround to allow current Linux to map the grant-table as WB using
+memremap() introduce an xl.cfg option (xen_platform_pci_bar_uc=0) that can
+be used to select whether the Xen platform PCI device BAR will have the UC
+attribute in MTRR.  Such workaround in hvmloader should also be paired with
+a fix for Linux so it attempts to change the MTRR of the Xen platform PCI
+device BAR to WB by itself.
+
+Overall, the long term solution would be to provide the guest with a safe
+range in the guest physical address space where mappings to foreign pages
+can be created.
+
+Some vif throughput performance figures provided by Anthoine from a 8
+vCPUs, 4GB of RAM HVM guest(s) running on AMD hardware:
+
+Without this patch:
+vm -> dom0: 1.1Gb/s
+vm -> vm:   5.0Gb/s
+
+With the patch:
+vm -> dom0: 4.5Gb/s
+vm -> vm:   7.0Gb/s
+
+Reported-by: Anthoine Bourgeois <anthoine.bourgeois@vates.tech>
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Oleksii Kurochko<oleksii.kurochko@gmail.com>
+Acked-by: Jan Beulich <jbeulich@suse.com> # hvmloader
+---
+Changes since v4:
+ - Rename to Xen platform PCI to avoid confusion.
+ - Set hvmloader BAR default to UC.
+ - Unconditionally write XS node in libxl.
+ - Introduce define for Xen PCI vendor ID.
+
+Changes since v3:
+ - Add changelog.
+ - Assign BARs normally for xenpci if special casing fails.
+
+Changes since v2:
+ - Add default value in xl.cfg.
+ - List xenstore path in the pandoc file.
+ - Adjust comment in hvmloader.
+ - Fix commit message MIO -> MMIO.
+
+Changes since v1:
+ - Leave the xenpci BAR as UC by default.
+ - Introduce an option to not set it as UC.
+---
+ CHANGELOG.md                            |  3 ++
+ docs/man/xl.cfg.5.pod.in                |  8 ++++
+ docs/misc/xenstore-paths.pandoc         |  5 +++
+ tools/firmware/hvmloader/config.h       |  2 +-
+ tools/firmware/hvmloader/pci.c          | 52 ++++++++++++++++++++++++-
+ tools/firmware/hvmloader/util.c         |  2 +-
+ tools/include/libxl.h                   |  9 +++++
+ tools/libs/light/libxl_create.c         |  1 +
+ tools/libs/light/libxl_dom.c            |  9 +++++
+ tools/libs/light/libxl_types.idl        |  1 +
+ tools/xl/xl_parse.c                     |  2 +
+ xen/include/public/hvm/hvm_xs_strings.h |  2 +
+ 12 files changed, 92 insertions(+), 4 deletions(-)
+
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index 75726fd9e9..148975c4e7 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+  - When building with Systemd support (./configure --enable-systemd), remove
+    libsystemd as a build dependency.  Systemd Notify support is retained, now
+    using a standalone library implementation.
++ - Allow controlling the MTRR cache attribute of the Xen platform PCI device
++   BAR for HVM guests, to improve performance of guests using it to map the
++   grant table or foreign memory.
+ 
+ ## [4.17.3](https://xenbits.xen.org/gitweb/?p=xen.git;a=shortlog;h=RELEASE-4.17.3)
+ 
+diff --git a/docs/man/xl.cfg.5.pod.in b/docs/man/xl.cfg.5.pod.in
+index bee0b9a889..ac35c8bf4c 100644
+--- a/docs/man/xl.cfg.5.pod.in
++++ b/docs/man/xl.cfg.5.pod.in
+@@ -2205,6 +2205,14 @@ Windows L<https://xenproject.org/windows-pv-drivers/>.
+ Setting B<xen_platform_pci=0> with the default device_model "qemu-xen"
+ requires at least QEMU 1.6.
+ 
++
++=item B<xen_platform_pci_bar_uc=BOOLEAN>
++
++B<x86 only:> Select whether the memory BAR of the Xen platform PCI device
++should have uncacheable (UC) cache attribute set in MTRR.
++
++Default is B<true>.
++
+ =item B<viridian=[ "GROUP", "GROUP", ...]> or B<viridian=BOOLEAN>
+ 
+ The groups of Microsoft Hyper-V (AKA viridian) compatible enlightenments
+diff --git a/docs/misc/xenstore-paths.pandoc b/docs/misc/xenstore-paths.pandoc
+index 5cd5c8a3b9..e26d123f0c 100644
+--- a/docs/misc/xenstore-paths.pandoc
++++ b/docs/misc/xenstore-paths.pandoc
+@@ -234,6 +234,11 @@ These xenstore values are used to override some of the default string
+ values in the SMBIOS table constructed in hvmloader. See the SMBIOS
+ table specification at http://www.dmtf.org/standards/smbios/ 
+ 
++#### ~/hvmloader/pci/xen-platform-pci-bar-uc = ("1"|"0") [HVM,INTERNAL]
++
++Select whether the Xen platform PCI device MMIO BAR will have the uncacheable
++cache attribute set in the MTRRs by hvmloader.
++
+ #### ~/bios-strings/oem-* = STRING [HVM,INTERNAL]
+ 
+ 1 to 99 OEM strings can be set in xenstore using values of the form
+diff --git a/tools/firmware/hvmloader/config.h b/tools/firmware/hvmloader/config.h
+index c82adf6dc5..f462f6cea1 100644
+--- a/tools/firmware/hvmloader/config.h
++++ b/tools/firmware/hvmloader/config.h
+@@ -58,7 +58,7 @@ extern uint8_t ioapic_version;
+ #define ACPI_TIS_HDR_ADDRESS 0xFED40F00UL
+ 
+ extern uint32_t pci_mem_start;
+-extern const uint32_t pci_mem_end;
++extern uint32_t pci_mem_end;
+ extern uint64_t pci_hi_mem_start, pci_hi_mem_end;
+ 
+ extern bool acpi_enabled;
+diff --git a/tools/firmware/hvmloader/pci.c b/tools/firmware/hvmloader/pci.c
+index c3c61ca060..6d9dfb89d8 100644
+--- a/tools/firmware/hvmloader/pci.c
++++ b/tools/firmware/hvmloader/pci.c
+@@ -29,8 +29,10 @@
+ #include <xen/hvm/hvm_xs_strings.h>
+ #include <xen/hvm/e820.h>
+ 
++#define PCI_VENDOR_ID_XEN       0x5853
++
+ uint32_t pci_mem_start = HVM_BELOW_4G_MMIO_START;
+-const uint32_t pci_mem_end = RESERVED_MEMBASE;
++uint32_t pci_mem_end = RESERVED_MEMBASE;
+ uint64_t pci_hi_mem_start = 0, pci_hi_mem_end = 0;
+ 
+ /*
+@@ -126,6 +128,8 @@ void pci_setup(void)
+      * option that will have the least impact.
+      */
+     bool allow_memory_relocate = 1;
++    /* Select the MTRR cache attribute of the xen platform pci device BAR. */
++    bool xenpci_bar_uc = true;
+ 
+     BUILD_BUG_ON((typeof(*pci_devfn_decode_type))PCI_COMMAND_IO !=
+                  PCI_COMMAND_IO);
+@@ -140,6 +144,12 @@ void pci_setup(void)
+     printf("Relocating guest memory for lowmem MMIO space %s\n",
+            allow_memory_relocate?"enabled":"disabled");
+ 
++    s = xenstore_read(HVM_XS_XEN_PLATFORM_PCI_BAR_UC, NULL);
++    if ( s )
++        xenpci_bar_uc = strtoll(s, NULL, 0);
++    printf("Xen platform PCI device BAR MTRR cache attribute set to %s\n",
++           xenpci_bar_uc ? "UC" : "WB");
++
+     s = xenstore_read("platform/mmio_hole_size", NULL);
+     if ( s )
+         mmio_hole_size = strtoll(s, NULL, 0);
+@@ -281,6 +291,44 @@ void pci_setup(void)
+             if ( bar_sz == 0 )
+                 continue;
+ 
++            if ( !xenpci_bar_uc &&
++                 ((bar_data & PCI_BASE_ADDRESS_SPACE) ==
++                   PCI_BASE_ADDRESS_SPACE_MEMORY) &&
++                 vendor_id == PCI_VENDOR_ID_XEN &&
++                 (device_id == 0x0001 || device_id == 0x0002) )
++            {
++                if ( is_64bar )
++                {
++                     printf("xen platform pci dev %02x:%x unexpected MMIO 64bit BAR%u\n",
++                            devfn >> 3, devfn & 7, bar);
++                     goto skip_xenpci;
++                }
++
++                if ( bar_sz > pci_mem_end ||
++                     ((pci_mem_end - bar_sz) & ~(bar_sz - 1)) < pci_mem_start )
++                {
++                     printf("xen platform pci dev %02x:%x BAR%u size %llx overflows low PCI hole\n",
++                            devfn >> 3, devfn & 7, bar, bar_sz);
++                     goto skip_xenpci;
++                }
++
++                /* Put unconditionally at the end of the low PCI MMIO hole. */
++                pci_mem_end -= bar_sz;
++                pci_mem_end &= ~(bar_sz - 1);
++                bar_data &= ~PCI_BASE_ADDRESS_MEM_MASK;
++                bar_data |= pci_mem_end;
++                pci_writel(devfn, bar_reg, bar_data);
++                pci_devfn_decode_type[devfn] |= PCI_COMMAND_MEMORY;
++
++                /* Prefix BAR address with a 0 to match format used below. */
++                printf("pci dev %02x:%x bar %02x size "PRIllx": 0%08x\n",
++                       devfn >> 3, devfn & 7, bar_reg,
++                       PRIllx_arg(bar_sz), bar_data);
++
++                continue;
++            }
++ skip_xenpci:
++
+             for ( i = 0; i < nr_bars; i++ )
+                 if ( bars[i].bar_sz < bar_sz )
+                     break;
+@@ -320,7 +368,7 @@ void pci_setup(void)
+         }
+ 
+         /* Enable bus master for this function later */
+-        pci_devfn_decode_type[devfn] = PCI_COMMAND_MASTER;
++        pci_devfn_decode_type[devfn] |= PCI_COMMAND_MASTER;
+     }
+ 
+     if ( mmio_hole_size )
+diff --git a/tools/firmware/hvmloader/util.c b/tools/firmware/hvmloader/util.c
+index 581b35e5cf..8633a62738 100644
+--- a/tools/firmware/hvmloader/util.c
++++ b/tools/firmware/hvmloader/util.c
+@@ -957,7 +957,7 @@ void hvmloader_acpi_build_tables(struct acpi_config *config,
+         config->table_flags |= ACPI_HAS_HPET;
+ 
+     config->pci_start = pci_mem_start;
+-    config->pci_len = pci_mem_end - pci_mem_start;
++    config->pci_len = RESERVED_MEMBASE - pci_mem_start;
+     if ( pci_hi_mem_end > pci_hi_mem_start )
+     {
+         config->pci_hi_start = pci_hi_mem_start;
+diff --git a/tools/include/libxl.h b/tools/include/libxl.h
+index 2eeb22fde9..54010b7997 100644
+--- a/tools/include/libxl.h
++++ b/tools/include/libxl.h
+@@ -1409,6 +1409,15 @@ void libxl_mac_copy(libxl_ctx *ctx, libxl_mac *dst, const libxl_mac *src);
+  */
+ #define LIBXL_HAVE_CREATEINFO_XEND_SUSPEND_EVTCHN_COMPAT
+ 
++/*
++ * LIBXL_HAVE_XEN_PLATFORM_PCI_BAR_UC
++ *
++ * libxl_domain_build_info contains a boolean 'u.hvm.xen_platform_pci_bar_uc'
++ * field to signal whether the XenPCI device BAR should have UC cache attribute
++ * set in MTRR.
++ */
++#define LIBXL_HAVE_XEN_PLATFORM_PCI_BAR_UC
++
+ typedef char **libxl_string_list;
+ void libxl_string_list_dispose(libxl_string_list *sl);
+ int libxl_string_list_length(const libxl_string_list *sl);
+diff --git a/tools/libs/light/libxl_create.c b/tools/libs/light/libxl_create.c
+index dbee32b7b7..7e37d3bb71 100644
+--- a/tools/libs/light/libxl_create.c
++++ b/tools/libs/light/libxl_create.c
+@@ -376,6 +376,7 @@ int libxl__domain_build_info_setdefault(libxl__gc *gc,
+         libxl_defbool_setdefault(&b_info->u.hvm.usb,                false);
+         libxl_defbool_setdefault(&b_info->u.hvm.vkb_device,         true);
+         libxl_defbool_setdefault(&b_info->u.hvm.xen_platform_pci,   true);
++        libxl_defbool_setdefault(&b_info->u.hvm.xen_platform_pci_bar_uc, true);
+         libxl_defbool_setdefault(&b_info->u.hvm.pirq,               false);
+ 
+         libxl_defbool_setdefault(&b_info->u.hvm.spice.enable, false);
+         if (!libxl_defbool_val(b_info->u.hvm.spice.enable) &&
+diff --git a/tools/libs/light/libxl_dom.c b/tools/libs/light/libxl_dom.c
+index f6311eea6e..b46ab28294 100644
+--- a/tools/libs/light/libxl_dom.c
++++ b/tools/libs/light/libxl_dom.c
+@@ -791,6 +791,15 @@ static int hvm_build_set_xs_values(libxl__gc *gc,
+             goto err;
+     }
+ 
++    if (info->type == LIBXL_DOMAIN_TYPE_HVM) {
++        path = GCSPRINTF("/local/domain/%d/" HVM_XS_XEN_PLATFORM_PCI_BAR_UC,
++                         domid);
++        ret = libxl__xs_printf(gc, XBT_NULL, path, "%d",
++            libxl_defbool_val(info->u.hvm.xen_platform_pci_bar_uc));
++        if (ret)
++            goto err;
++    }
++
+     return 0;
+ 
+ err:
+diff --git a/tools/libs/light/libxl_types.idl b/tools/libs/light/libxl_types.idl
+index 82328b1414..596555c4d2 100644
+--- a/tools/libs/light/libxl_types.idl
++++ b/tools/libs/light/libxl_types.idl
+@@ -628,6 +628,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
+                                        ("vkb_device",       libxl_defbool),
+                                        ("soundhw",          string),
+                                        ("xen_platform_pci", libxl_defbool),
++                                       ("xen_platform_pci_bar_uc", libxl_defbool),
+                                        ("usbdevice_list",   libxl_string_list),
+                                        ("vendor_device",    libxl_vendor_device),
+                                        # See libxl_ms_vm_genid_generate()
+diff --git a/tools/xl/xl_parse.c b/tools/xl/xl_parse.c
+index 1d8fd108af..ee85006412 100644
+--- a/tools/xl/xl_parse.c
++++ b/tools/xl/xl_parse.c
+@@ -2710,6 +2710,8 @@ skip_usbdev:
+         xlu_cfg_replace_string (config, "soundhw", &b_info->u.hvm.soundhw, 0);
+         xlu_cfg_get_defbool(config, "xen_platform_pci",
+                             &b_info->u.hvm.xen_platform_pci, 0);
++        xlu_cfg_get_defbool(config, "xen_platform_pci_bar_uc",
++                            &b_info->u.hvm.xen_platform_pci_bar_uc, 0);
+ 
+         if(b_info->u.hvm.vnc.listen
+            && b_info->u.hvm.vnc.display
+diff --git a/xen/include/public/hvm/hvm_xs_strings.h b/xen/include/public/hvm/hvm_xs_strings.h
+index e1ed078628..e977d5a8b1 100644
+--- a/xen/include/public/hvm/hvm_xs_strings.h
++++ b/xen/include/public/hvm/hvm_xs_strings.h
+@@ -14,6 +14,8 @@
+ #define HVM_XS_BIOS                    "hvmloader/bios"
+ #define HVM_XS_GENERATION_ID_ADDRESS   "hvmloader/generation-id-address"
+ #define HVM_XS_ALLOW_MEMORY_RELOCATE   "hvmloader/allow-memory-relocate"
++/* Set Xen platform pci device BAR as UC in MTRR */
++#define HVM_XS_XEN_PLATFORM_PCI_BAR_UC "hvmloader/pci/xen-platform-pci-bar-uc"
+ 
+ /* The following values allow additional ACPI tables to be added to the
+  * virtual ACPI BIOS that hvmloader constructs. The values specify the guest
+-- 
+2.49.0
+

--- a/SOURCES/0002-tools-golang-update-auto-generated-libxl-based-types.patch
+++ b/SOURCES/0002-tools-golang-update-auto-generated-libxl-based-types.patch
@@ -1,0 +1,63 @@
+From fd06f87007698dd2a669922dcf4dcd69fa525e5b Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Wed, 2 Jul 2025 11:52:48 +0200
+Subject: [PATCH] tools/golang: update auto-generated libxl based types
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+As a result of the addition of a new field in libxl domain build info
+structure the golang types need to be regnerated, this was missing as part
+of 22650d6054.
+
+Regenerate the headers now.
+
+Reported-by: Juergen Gross <jgross@suse.com>
+Fixes: 22650d605462 ('x86/hvmloader: select xen platform pci MMIO BAR UC or WB MTRR cache attribute')
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Juergen Gross <jgross@suse.com>
+Acked-by: Nick Rosbrook <enr0n@ubuntu.com>
+---
+ tools/golang/xenlight/helpers.gen.go | 6 ++++++
+ tools/golang/xenlight/types.gen.go   | 1 +
+ 2 files changed, 7 insertions(+)
+
+diff --git a/tools/golang/xenlight/helpers.gen.go b/tools/golang/xenlight/helpers.gen.go
+index 191be87297..c45df1005f 100644
+--- a/tools/golang/xenlight/helpers.gen.go
++++ b/tools/golang/xenlight/helpers.gen.go
+@@ -1277,6 +1277,9 @@ x.Soundhw = C.GoString(tmp.soundhw)
+ if err := x.XenPlatformPci.fromC(&tmp.xen_platform_pci);err != nil {
+ return fmt.Errorf("converting field XenPlatformPci: %v", err)
+ }
++if err := x.XenPlatformPciBarUc.fromC(&tmp.xen_platform_pci_bar_uc);err != nil {
++return fmt.Errorf("converting field XenPlatformPciBarUc: %v", err)
++}
+ if err := x.UsbdeviceList.fromC(&tmp.usbdevice_list);err != nil {
+ return fmt.Errorf("converting field UsbdeviceList: %v", err)
+ }
+@@ -1621,6 +1624,9 @@ hvm.soundhw = C.CString(tmp.Soundhw)}
+ if err := tmp.XenPlatformPci.toC(&hvm.xen_platform_pci); err != nil {
+ return fmt.Errorf("converting field XenPlatformPci: %v", err)
+ }
++if err := tmp.XenPlatformPciBarUc.toC(&hvm.xen_platform_pci_bar_uc); err != nil {
++return fmt.Errorf("converting field XenPlatformPciBarUc: %v", err)
++}
+ if err := tmp.UsbdeviceList.toC(&hvm.usbdevice_list); err != nil {
+ return fmt.Errorf("converting field UsbdeviceList: %v", err)
+ }
+diff --git a/tools/golang/xenlight/types.gen.go b/tools/golang/xenlight/types.gen.go
+index 656933c6c9..61e322f20a 100644
+--- a/tools/golang/xenlight/types.gen.go
++++ b/tools/golang/xenlight/types.gen.go
+@@ -654,6 +654,7 @@ Usbdevice string
+ VkbDevice Defbool
+ Soundhw string
+ XenPlatformPci Defbool
++XenPlatformPciBarUc Defbool
+ UsbdeviceList StringList
+ VendorDevice VendorDevice
+ MsVmGenid MsVmGenid
+-- 
+2.49.1
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -33,7 +33,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.5
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.5.tar.gz
@@ -299,6 +299,8 @@ Patch254: vtpm-ppi-acpi-dsm.patch
 
 # XCP-ng patches
 Patch1000: 0001-xenguest-activate-nested-virt-when-requested.patch
+Patch1001: 0001-x86-hvmloader-select-xen-platform-pci-MMIO-BAR-UC-or.patch
+Patch1002: 0002-tools-golang-update-auto-generated-libxl-based-types.patch
 
 ExclusiveArch: x86_64
 
@@ -1144,6 +1146,11 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Fri Jul 11 2025 Anthoine Bourgeois <anthoine.bourgeois@vates.tech> - 4.17.5-15.2
+- Backport 22650d605462 "x86/hvmloader: select xen platform pci MMIO BAR UC or WB MTRR
+  cache attributes"
+- Backport fd06f8700769 "tools/golang: update auto-generated libxl based types"
+
 * Wed Jul 09 2025 Teddy Astie <teddy.astie@vates.tech> - 4.17.5-15.1
 - Sync with 4.17.5-15
 - *** Upstream changelog ***


### PR DESCRIPTION
This patch is a workaround for a uncachd grant tables in the HVM Linux guest kernel. The cache memory type problem is specific to AMD cpus.

My patch [x86/hvmloader: don't set xenpci MMIO BAR as UC in MTRR](https://lore.kernel.org/xen-devel/20250530092314.27306-1-roger.pau@citrix.com/) is slightly different because not on the same base.

Note that the fix is not upstream yet. Only on the mailing list.