### PR TITLE
Disable transitive grants by default

### DIFF
--- a/SOURCES/Disable-transitive-grants.patch
+++ b/SOURCES/Disable-transitive-grants.patch
@@ -1,0 +1,34 @@
+From bfc2ea81f613250ebe30253f4d589b308badf403 Mon Sep 17 00:00:00 2001
+Message-ID: <bfc2ea81f613250ebe30253f4d589b308badf403.1753797078.git.teddy.astie@vates.tech>
+From: Teddy Astie <teddy.astie@vates.tech>
+Date: Tue, 29 Jul 2025 15:51:12 +0200
+Subject: [PATCH] Disable transitive grants
+
+No guest uses this features, and even then, XSM SILO should make it unusable.
+It's hard asserting the security aspect of transitive grants wrt. XSM, e.g 2
+guests may be able to use it to mount a covert channel, which could be seen as
+XCP-ng vulnerability.
+
+Disable the feature by default.
+
+Signed-off-by: Teddy Astie <teddy.astie@vates.tech>
+---
+ xen/common/grant_table.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xen/common/grant_table.c b/xen/common/grant_table.c
+index 62a8685cd5..036f35dff5 100644
+--- a/xen/common/grant_table.c
++++ b/xen/common/grant_table.c
+@@ -183,7 +183,7 @@ static int cf_check parse_gnttab_max_maptrack_frames(const char *arg)
+ #endif
+ 
+ unsigned int __read_mostly opt_gnttab_max_version = GNTTAB_MAX_VERSION;
+-static bool __read_mostly opt_transitive_grants = true;
++static bool __read_mostly opt_transitive_grants = false;
+ #ifdef CONFIG_PV
+ static bool __ro_after_init opt_grant_transfer = true;
+ #else
+-- 
+2.50.1
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -33,7 +33,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.5
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.5.tar.gz
@@ -301,6 +301,7 @@ Patch254: vtpm-ppi-acpi-dsm.patch
 Patch1000: 0001-xenguest-activate-nested-virt-when-requested.patch
 Patch1001: 0001-x86-hvmloader-select-xen-platform-pci-MMIO-BAR-UC-or.patch
 Patch1002: 0002-tools-golang-update-auto-generated-libxl-based-types.patch
+Patch1003: Disable-transitive-grants.patch
 
 ExclusiveArch: x86_64
 
@@ -1146,6 +1147,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Tue Jul 29 2025 Teddy Astie <teddy.astie@vates.tech> - 4.17.5-15.3
+- Disable transitive grants by default
+
 * Fri Jul 11 2025 Anthoine Bourgeois <anthoine.bourgeois@vates.tech> - 4.17.5-15.2
 - Backport 22650d605462 "x86/hvmloader: select xen platform pci MMIO BAR UC or WB MTRR
   cache attributes"


### PR DESCRIPTION
Transitive grant is not a used feature (no guest use it), and even then should not be usable with XSM SILO policy (should prevent it, aside potential security bugs).
Yet we still expose it to the guests (making it potentially exploitable).

Disable it by default for security hardening.