### PR TITLE
hvmloader: Add SMBIOS 2.6 patch and legacy option

### DIFF
--- a/SOURCES/0001-hvmloader-Update-to-SMBIOS-2.6.patch
+++ b/SOURCES/0001-hvmloader-Update-to-SMBIOS-2.6.patch
@@ -1,0 +1,71 @@
+From b569a298a6270ae04eaf433f7de9ce1f3e248e5f Mon Sep 17 00:00:00 2001
+Message-ID: <b569a298a6270ae04eaf433f7de9ce1f3e248e5f.1756287587.git.teddy.astie@vates.tech>
+From: Teddy Astie <teddy.astie@vates.tech>
+Date: Fri, 22 Aug 2025 15:43:32 +0200
+Subject: [PATCH] hvmloader: Update to SMBIOS 2.6
+
+Currently, hvmloader uses SMBIOS 2.4, however, when using OVMF, the
+SMBIOS is patched to 2.8, which has clarified the UUID format (as GUID).
+
+In Linux, if the SMBIOS version is >= 2.6, the GUID format is used, else
+(undefined as per SMBIOS spec), big endian is used (used by Xen). Therefore,
+you have a endian mismatch causing the UUIDs to mismatch in the guest.
+
+$ cat /sys/hypervisor/uuid
+e865e63f-3d30-4f0b-83e0-8fdfc1e30eb7
+$ cat /sys/devices/virtual/dmi/id/product_uuid
+3fe665e8-303d-0b4f-83e0-8fdfc1e30eb7
+$ cat /sys/devices/virtual/dmi/id/product_serial
+e865e63f-3d30-4f0b-83e0-8fdfc1e30eb7
+
+This patch updates the SMBIOS version from 2.4 to 2.6 and fixup the UUID
+written in the table; which effectively fix this endianness mismatch with
+OVMF; while the UUID displayed by Linux is still the same for SeaBIOS.
+
+Signed-off-by: Teddy Astie <teddy.astie@vates.tech>
+Link: https://lore.kernel.org/xen-devel/b569a298a6270ae04eaf433f7de9ce1f3e248e5f.1755870287.git.teddy.astie@vates.tech/
+---
+ tools/firmware/hvmloader/smbios.c | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/tools/firmware/hvmloader/smbios.c b/tools/firmware/hvmloader/smbios.c
+index 6bcdcc233a..f4822ae6f8 100644
+--- a/tools/firmware/hvmloader/smbios.c
++++ b/tools/firmware/hvmloader/smbios.c
+@@ -352,7 +352,7 @@ smbios_entry_point_init(void *start,
+     memcpy(ep->anchor_string, "_SM_", 4);
+     ep->length = 0x1f;
+     ep->smbios_major_version = 2;
+-    ep->smbios_minor_version = 4;
++    ep->smbios_minor_version = 6;
+     ep->max_structure_size = max_structure_size;
+     ep->entry_point_revision = 0;
+     memcpy(ep->intermediate_anchor_string, "_DMI_", 5);
+@@ -462,7 +462,23 @@ smbios_type_1_init(void *start, const char *xen_version,
+     p->version_str = 3;
+     p->serial_number_str = 4;
+ 
+-    memcpy(p->uuid, uuid, 16);
++    /*
++     * Xen uses OSF DCE UUIDs which is fully big endian, however,
++     * GUIDs (which requirement is clarified by SMBIOS >= 2.6) has the
++     * first 3 components appearing as being little endian and the rest
++     * as still being big endian.
++     */
++    /* First component */
++    for ( unsigned int i = 0; i < 4; i++ )
++        p->uuid[i] = uuid[4 - i - 1];
++    /* Second component */
++    p->uuid[4] = uuid[5];
++    p->uuid[5] = uuid[4];
++    /* Third component */
++    p->uuid[6] = uuid[7];
++    p->uuid[7] = uuid[6];
++    /* Rest */
++    memcpy(p->uuid + 8, uuid + 8, 8);
+ 
+     p->wake_up_type = 0x06; /* power switch */
+     p->sku_str = 0;
+-- 
+2.50.1
+

--- a/SOURCES/0002-hvmloader-Add-a-temporary-way-of-forcing-legacy-SMBI.patch
+++ b/SOURCES/0002-hvmloader-Add-a-temporary-way-of-forcing-legacy-SMBI.patch
@@ -1,0 +1,73 @@
+From 4c2c99da705747718db75583b5e96fde310314e6 Mon Sep 17 00:00:00 2001
+Message-ID: <4c2c99da705747718db75583b5e96fde310314e6.1756287587.git.teddy.astie@vates.tech>
+In-Reply-To: <b569a298a6270ae04eaf433f7de9ce1f3e248e5f.1756287587.git.teddy.astie@vates.tech>
+References: <b569a298a6270ae04eaf433f7de9ce1f3e248e5f.1756287587.git.teddy.astie@vates.tech>
+From: Teddy Astie <teddy.astie@vates.tech>
+Date: Wed, 27 Aug 2025 11:39:32 +0200
+Subject: [PATCH] hvmloader: Add a temporary way of forcing legacy SMBIOS
+
+Add a temporary knob for reversing "Update to SMBIOS 2.6" if found problematic.
+
+Setting the guest xenstore variable "hvmloader/smbios/force_legacy" to 1 forces the legacy behavior.
+
+Signed-off-by: Teddy Astie <teddy.astie@vates.tech>
+---
+This patch can be safely removed if it proves to be unnecessary.
+---
+ tools/firmware/hvmloader/smbios.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/tools/firmware/hvmloader/smbios.c b/tools/firmware/hvmloader/smbios.c
+index f4822ae6f8..86e26f22d2 100644
+--- a/tools/firmware/hvmloader/smbios.c
++++ b/tools/firmware/hvmloader/smbios.c
+@@ -99,6 +99,7 @@ smbios_type_127_init(void *start);
+ 
+ static uint32_t *smbios_pt_addr = NULL;
+ static uint32_t smbios_pt_length = 0;
++static bool smbios_force_legacy = false;
+ 
+ static void
+ smbios_pt_init(void)
+@@ -311,6 +312,11 @@ hvm_write_smbios_tables(
+ 
+     xen_version_str[sizeof(xen_version_str)-1] = '\0';
+ 
++    smbios_force_legacy = strtoll(xenstore_read("hvmloader/smbios/force_legacy", "0"),
++                                  NULL, 0);
++    if ( smbios_force_legacy )
++        printf("Forcing legacy SMBIOS table version\n");
++
+     /* scratch_start is a safe large memory area for scratch. */
+     len = write_smbios_tables((void *)ep, (void *)scratch_start,
+                               hvm_info->nr_vcpus, get_memsize(),
+@@ -352,7 +358,7 @@ smbios_entry_point_init(void *start,
+     memcpy(ep->anchor_string, "_SM_", 4);
+     ep->length = 0x1f;
+     ep->smbios_major_version = 2;
+-    ep->smbios_minor_version = 6;
++    ep->smbios_minor_version = smbios_force_legacy ? 4 : 6;
+     ep->max_structure_size = max_structure_size;
+     ep->entry_point_revision = 0;
+     memcpy(ep->intermediate_anchor_string, "_DMI_", 5);
+@@ -462,6 +468,9 @@ smbios_type_1_init(void *start, const char *xen_version,
+     p->version_str = 3;
+     p->serial_number_str = 4;
+ 
++    if ( smbios_force_legacy )
++        memcpy(p->uuid, uuid, 16);
++    else {
+     /*
+      * Xen uses OSF DCE UUIDs which is fully big endian, however,
+      * GUIDs (which requirement is clarified by SMBIOS >= 2.6) has the
+@@ -479,6 +488,7 @@ smbios_type_1_init(void *start, const char *xen_version,
+     p->uuid[7] = uuid[6];
+     /* Rest */
+     memcpy(p->uuid + 8, uuid + 8, 8);
++    }
+ 
+     p->wake_up_type = 0x06; /* power switch */
+     p->sku_str = 0;
+-- 
+2.50.1
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -33,7 +33,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.5
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.5.tar.gz
@@ -301,6 +301,11 @@ Patch254: vtpm-ppi-acpi-dsm.patch
 Patch1000: 0001-xenguest-activate-nested-virt-when-requested.patch
 Patch1001: 0001-x86-hvmloader-select-xen-platform-pci-MMIO-BAR-UC-or.patch
 Patch1002: 0002-tools-golang-update-auto-generated-libxl-based-types.patch
+
+# SMBIOS 2.6 patches
+Patch1003: 0001-hvmloader-Update-to-SMBIOS-2.6.patch
+# Legacy SMBIOS (2.4) behavior toggle
+Patch1004: 0002-hvmloader-Add-a-temporary-way-of-forcing-legacy-SMBI.patch
 
 ExclusiveArch: x86_64
 
@@ -1146,6 +1151,10 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Wed Aug 27 2025 Teddy Astie <teddy.astie@vates.tech> - 4.17.5-15.3
+- Update SMBIOS version to 2.6, fixing UUID endianness issues.
+- Add a way to force legacy SMBIOS version (and behavior).
+
 * Fri Jul 11 2025 Anthoine Bourgeois <anthoine.bourgeois@vates.tech> - 4.17.5-15.2
 - Backport 22650d605462 "x86/hvmloader: select xen platform pci MMIO BAR UC or WB MTRR
   cache attributes"


### PR DESCRIPTION
This changes updates by default the SMBIOS to 2.6 and writes the guest UUID as GUID (according to the SMBIOS 2.6+ spec).
It is expected to fix various issues guest UUID (from XAPI/XO) mismatching the one SMBIOS tables, notably :
- UUIDs read from Windows (I assume they are considered as GUID); both BIOS and UEFI
- UUIDs read from Linux using dmidecode or /sys/devices/virtual/dmi/id/product_uuid in UEFI mode

Expected to fix https://github.com/vatesfr/xenorchestra-cloud-controller-manager/issues/10 and third-party tools that relies on the SMBIOS UUID matching the Xen Orchestra/XAPI one.

This fix can be disabled on a per-guest basis through xenstore (forcing SMBIOS 2.4 behavior).