### PR TITLE
Backport XSA-472 patches for 8.2

### DIFF
--- a/SOURCES/xsa472-1.patch
+++ b/SOURCES/xsa472-1.patch
@@ -1,0 +1,43 @@
+From 262114a440bf7c32fd6d215e243b3eaebdd6d7cd Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Thu, 10 Jul 2025 15:51:40 +0200
+Subject: [PATCH 1/3] x86/viridian: avoid NULL pointer dereference in
+ update_reference_tsc()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The function is only called when the MSR has the enabled bit set, but even
+then the page might not be mapped because the guest provided gfn is not
+suitable.
+
+Prevent a NULL pointer dereference in update_reference_tsc() by checking
+whether the page is mapped.
+
+This is CVE-2025-27466 / part of XSA-472.
+
+Fixes: 386b3365221d ('viridian: use viridian_map/unmap_guest_page() for reference tsc page')
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+Backported to 8.2.
+Backport notes:
+- Minor index changes.
+
+Backported-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+Signed-off-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+diff --git a/xen/arch/x86/hvm/viridian/time.c b/xen/arch/x86/hvm/viridian/time.c
+index 3810578..bfe447b 100644
+--- a/xen/arch/x86/hvm/viridian/time.c
++++ b/xen/arch/x86/hvm/viridian/time.c
+@@ -34,6 +34,10 @@ static void update_reference_tsc(const struct domain *d, bool initialize)
+     HV_REFERENCE_TSC_PAGE *p = rt->ptr;
+     uint32_t seq;
+ 
++    /* Reference TSC page might not be mapped even if the MSR is enabled. */
++    if ( !p )
++        return;
++
+     if ( initialize )
+         clear_page(p);
+ 

--- a/SOURCES/xsa472-2.patch
+++ b/SOURCES/xsa472-2.patch
@@ -1,0 +1,43 @@
+From 71c9568e290b51dfd7ab091ac98b272fd0aa0b90 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Thu, 10 Jul 2025 15:58:51 +0200
+Subject: [PATCH 2/3] x86/viridian: avoid NULL pointer dereference in
+ viridian_synic_deliver_timer_msg()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The function is called unconditionally, regardless of whether the SIM page
+is mapped.  Avoid a NULL pointer dereference in
+viridian_synic_deliver_timer_msg() by checking whether the SIM page is
+mapped.
+
+This is CVE-2025-58142 / part of XSA-472.
+
+Fixes: 26fba3c85571 ('viridian: add implementation of synthetic timers')
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+Backported to 8.2.
+Backport notes:
+- The if ( !msg ) check was added before the existing msg_pending check
+  that was removed in 391a8b6d20b7.
+- Minor index changes.
+
+Backported-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+Signed-off-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+diff --git a/xen/arch/x86/hvm/viridian/synic.c b/xen/arch/x86/hvm/viridian/synic.c
+index f9a602a..af81433 100644
+--- a/xen/arch/x86/hvm/viridian/synic.c
++++ b/xen/arch/x86/hvm/viridian/synic.c
+@@ -370,6 +370,10 @@ bool viridian_synic_deliver_timer_msg(struct vcpu *v, unsigned int sintx,
+         .DeliveryTime = delivery,
+     };
+ 
++    /* Don't assume SIM page to be mapped. */
++    if ( !msg )
++        return false;
++
+     if ( test_bit(sintx, &vv->msg_pending) )
+         return false;
+ 

--- a/SOURCES/xsa472-3.patch
+++ b/SOURCES/xsa472-3.patch
@@ -1,0 +1,93 @@
+From aed4cfd64d178aee677a8790440addda03678cd6 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Thu, 3 Jul 2025 13:09:03 +0200
+Subject: [PATCH 3/3] x86/viridian: protect concurrent modification of the
+ reference TSC page
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The reference TSC page is shared between all vCPUs, and the data stored in
+the domain struct.  However the handlers to set and clear it are not safe
+against concurrent accesses.  It's possible for two (or more) vCPUs to call
+HV_X64_MSR_REFERENCE_TSC at the same time and cause the in-use reference
+TSC page to be freed, while still being on the p2m.  This creates an
+information leak, where the page can end up mapped in another domain while
+still being part of the original domain p2m.
+
+It's also possible to underflow the reference counter, as multiple
+concurrent writes to HV_X64_MSR_REFERENCE_TSC can create an imbalance on
+the number of put_page_and_type() calls.
+
+Introduce a lock to protect the reference TSC domain field, thus
+serializing concurrent vCPU accesses.
+
+This is CVE-2025-58143 / part of XSA-472.
+
+Fixes: 386b3365221d ('viridian: use viridian_map/unmap_guest_page() for reference tsc page')
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+Backported to 8.2.
+Backport notes:
+- xen/arch/x86/include/asm/hvm/viridian.h -> xen/include/asm-x86/hvm/viridian.h
+- Minor index changes
+
+Backported-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+Signed-off-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+diff --git a/xen/arch/x86/hvm/viridian/time.c b/xen/arch/x86/hvm/viridian/time.c
+index bfe447b..1f95e2d 100644
+--- a/xen/arch/x86/hvm/viridian/time.c
++++ b/xen/arch/x86/hvm/viridian/time.c
+@@ -151,8 +151,10 @@ static void time_ref_count_thaw(const struct domain *d)
+ 
+     trc->off = (int64_t)trc->val - trc_val(d, 0);
+ 
++    spin_lock(&vd->lock);
+     if ( vd->reference_tsc.msr.enabled )
+         update_reference_tsc(d, false);
++    spin_unlock(&vd->lock);
+ }
+ 
+ static uint64_t time_ref_count(const struct domain *d)
+@@ -374,6 +376,7 @@ int viridian_time_wrmsr(struct vcpu *v, uint32_t idx, uint64_t val)
+         if ( !(viridian_feature_mask(d) & HVMPV_reference_tsc) )
+             return X86EMUL_EXCEPTION;
+ 
++        spin_lock(&vd->lock);
+         viridian_unmap_guest_page(&vd->reference_tsc);
+         vd->reference_tsc.msr.raw = val;
+         viridian_dump_guest_page(v, "REFERENCE_TSC", &vd->reference_tsc);
+@@ -382,6 +385,7 @@ int viridian_time_wrmsr(struct vcpu *v, uint32_t idx, uint64_t val)
+             viridian_map_guest_page(d, &vd->reference_tsc);
+             update_reference_tsc(d, true);
+         }
++        spin_unlock(&vd->lock);
+         break;
+ 
+     case HV_X64_MSR_TIME_REF_COUNT:
+diff --git a/xen/arch/x86/hvm/viridian/viridian.c b/xen/arch/x86/hvm/viridian/viridian.c
+index ca20c48..6fa44f8 100644
+--- a/xen/arch/x86/hvm/viridian/viridian.c
++++ b/xen/arch/x86/hvm/viridian/viridian.c
+@@ -481,6 +481,8 @@ int viridian_domain_init(struct domain *d)
+     if ( !d->arch.hvm.viridian )
+         return -ENOMEM;
+ 
++    spin_lock_init(&d->arch.hvm.viridian->lock);
++
+     rc = viridian_synic_domain_init(d);
+     if ( rc )
+         goto fail;
+diff --git a/xen/include/asm-x86/hvm/viridian.h b/xen/include/asm-x86/hvm/viridian.h
+index 010c8b5..6c47a90 100644
+--- a/xen/include/asm-x86/hvm/viridian.h
++++ b/xen/include/asm-x86/hvm/viridian.h
+@@ -116,6 +116,7 @@ struct viridian_domain
+     union viridian_page_msr hypercall_gpa;
+     struct viridian_time_ref_count time_ref_count;
+     struct viridian_page reference_tsc;
++    spinlock_t lock;
+ };
+ 
+ void cpuid_viridian_leaves(const struct vcpu *v, uint32_t leaf,

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -34,7 +34,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.13.5
-Release: %{?xsrel}.3%{?dist}
+Release: %{?xsrel}.4%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.13.5.tar.gz
@@ -577,6 +577,11 @@ Patch1036: 0035-x86-cpu-policy-Infrastructure-for-CPUID-leaf-0x80000.patch
 Patch1037: 0036-x86-ucode-Digests-for-TSA-microcode.patch
 Patch1038: 0037-x86-idle-Rearrange-VERW-and-MONITOR-in-mwait_idle_wi.patch
 Patch1039: 0038-x86-spec-ctrl-Mitigate-Transitive-Scheduler-Attacks.patch
+
+# XSA-472
+Patch1040: xsa472-1.patch
+Patch1041: xsa472-2.patch
+Patch1042: xsa472-3.patch
 
 ExclusiveArch: x86_64
 
@@ -1419,6 +1424,9 @@ touch %{_rundir}/reboot-required.d/%{name}/%{version}-%{release}
 %{?_cov_results_package}
 
 %changelog
+* Wed Aug 27 2025 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.13.5-9.49.4
+- Security fix for XSA-472 "Multiple vulnerabilities in the Viridian interface"
+
 * Tue Jul 22 2025 Thierry Escande <thierry.escande@vates.tech> - 4.13.5-9.49.3
 - Backport fix for XSA-471 patchset from Xen 4.17 to 4.13
 - Backport mwait-idle driver fixes (for XSA-471 patches to apply correctly)


### PR DESCRIPTION
Backport notes:

`xsa472-1.patch`:
- Minor index changes.

`xsa472-2.patch`:
- The if ( !msg ) check was added before the existing msg_pending check
  that was removed in 391a8b6d20b7.
- Minor index changes.

`xsa472-3.patch`:
- `xen/arch/x86/include/asm/hvm/viridian.h` -> `xen/include/asm-x86/hvm/viridian.h`
- Minor index changes

---

### Work Item Reference

_If this change is related to a Vates internal task or issue, please provide a work item reference. Otherwise, leave this blank._

XCPNG-1375

---

### Why should this change be accepted as an update to XCP-ng?

_Explain the motivation, problem being solved, or benefit to users or maintainers._

This is a backport for XSA-472 "Mutiple vulnerabilities in the Viridian interface".

---

### Release Notes

#### Explain the change for users

_Write a user-facing explanation which will serve as a basis for public announcements._
_Good release notes explain what changes, who is concerned, and how it affects them. It's not a technical changelog._

- Security fix for XSA-472 "Multiple vulnerabilities in the Viridian interface"

#### Do users or support need to be aware of anything specific related to the update?

_Any manual steps, changes to default behavior, compatibility issues, etc._

- [x] Yes
- [ ] No

_If yes, provide details._

A workaround is available for those who can't patch: Not enabling the reference_tsc and stimer viridian extensions will avoid the issues.

For all VMs with Viridian enabled:

```
xe vm-param-set uuid=<vm uuid> platform:viridian_reference_tsc=false
xe vm-param-set uuid=<vm uuid> platform:viridian_stimer=false
```

---

### Testing and regression avoidance

#### What tests have you done?

_1. Regarding the change itself._

Not yet (no 8.2 host)

_2. Regarding potential regressions._

Not yet

#### What tests in current test suites cover this change?

_1. Regarding the change itself._

main-multi-windows

_2. Regarding potential regressions._

main-multi-windows

#### What tests were or will be added to CI for this change? If none, explain why.

_1. Regarding the change itself._

N/A

_2. To ensure there are no regressions._

N/A

#### What other tests should reviewers or testers perform (after the build)?

_1. Regarding the change itself._

N/A

_2. Regarding potential regressions._

N/A

---

### Documentation

#### Should existing documentation be updated, or new documentation be added?

- [ ] Yes
- [x] No

_If yes, explain what needs to be updated or added, and where. If no, explain why._

This is a security fix. For XSA-472 in particular, no user documentation is needed.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add features that could be useful for Xen Orchestra?

- [ ] Yes
- [x] No

_If yes, describe which features and how._

N/A