### PR TITLE
Backport XSA-472 patches for 8.3

### DIFF
--- a/SOURCES/xsa472-1.patch
+++ b/SOURCES/xsa472-1.patch
@@ -1,0 +1,43 @@
+From 262114a440bf7c32fd6d215e243b3eaebdd6d7cd Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Thu, 10 Jul 2025 15:51:40 +0200
+Subject: [PATCH 1/3] x86/viridian: avoid NULL pointer dereference in
+ update_reference_tsc()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The function is only called when the MSR has the enabled bit set, but even
+then the page might not be mapped because the guest provided gfn is not
+suitable.
+
+Prevent a NULL pointer dereference in update_reference_tsc() by checking
+whether the page is mapped.
+
+This is CVE-2025-27466 / part of XSA-472.
+
+Fixes: 386b3365221d ('viridian: use viridian_map/unmap_guest_page() for reference tsc page')
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+Backported to 8.3.
+Backport notes:
+- Minor index changes.
+
+Backported-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+Signed-off-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+diff --git a/xen/arch/x86/hvm/viridian/time.c b/xen/arch/x86/hvm/viridian/time.c
+index b56fd67..97caf0b 100644
+--- a/xen/arch/x86/hvm/viridian/time.c
++++ b/xen/arch/x86/hvm/viridian/time.c
+@@ -27,6 +27,10 @@ static void update_reference_tsc(const struct domain *d, bool initialize)
+     HV_REFERENCE_TSC_PAGE *p = rt->ptr;
+     uint32_t seq;
+ 
++    /* Reference TSC page might not be mapped even if the MSR is enabled. */
++    if ( !p )
++        return;
++
+     if ( initialize )
+         clear_page(p);
+ 

--- a/SOURCES/xsa472-2.patch
+++ b/SOURCES/xsa472-2.patch
@@ -1,0 +1,41 @@
+From 71c9568e290b51dfd7ab091ac98b272fd0aa0b90 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Thu, 10 Jul 2025 15:58:51 +0200
+Subject: [PATCH 2/3] x86/viridian: avoid NULL pointer dereference in
+ viridian_synic_deliver_timer_msg()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The function is called unconditionally, regardless of whether the SIM page
+is mapped.  Avoid a NULL pointer dereference in
+viridian_synic_deliver_timer_msg() by checking whether the SIM page is
+mapped.
+
+This is CVE-2025-58142 / part of XSA-472.
+
+Fixes: 26fba3c85571 ('viridian: add implementation of synthetic timers')
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+Backported to 8.3.
+Backport notes:
+- Minor index changes.
+
+Backported-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+Signed-off-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+diff --git a/xen/arch/x86/hvm/viridian/synic.c b/xen/arch/x86/hvm/viridian/synic.c
+index 483fa95..6eda460 100644
+--- a/xen/arch/x86/hvm/viridian/synic.c
++++ b/xen/arch/x86/hvm/viridian/synic.c
+@@ -339,6 +339,10 @@ bool viridian_synic_deliver_timer_msg(struct vcpu *v, unsigned int sintx,
+         .DeliveryTime = delivery,
+     };
+ 
++    /* Don't assume SIM page to be mapped. */
++    if ( !msg )
++        return false;
++
+     /*
+      * To avoid using an atomic test-and-set, and barrier before calling
+      * vlapic_set_irq(), this function must be called in context of the

--- a/SOURCES/xsa472-3.patch
+++ b/SOURCES/xsa472-3.patch
@@ -1,0 +1,92 @@
+From aed4cfd64d178aee677a8790440addda03678cd6 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Thu, 3 Jul 2025 13:09:03 +0200
+Subject: [PATCH 3/3] x86/viridian: protect concurrent modification of the
+ reference TSC page
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The reference TSC page is shared between all vCPUs, and the data stored in
+the domain struct.  However the handlers to set and clear it are not safe
+against concurrent accesses.  It's possible for two (or more) vCPUs to call
+HV_X64_MSR_REFERENCE_TSC at the same time and cause the in-use reference
+TSC page to be freed, while still being on the p2m.  This creates an
+information leak, where the page can end up mapped in another domain while
+still being part of the original domain p2m.
+
+It's also possible to underflow the reference counter, as multiple
+concurrent writes to HV_X64_MSR_REFERENCE_TSC can create an imbalance on
+the number of put_page_and_type() calls.
+
+Introduce a lock to protect the reference TSC domain field, thus
+serializing concurrent vCPU accesses.
+
+This is CVE-2025-58143 / part of XSA-472.
+
+Fixes: 386b3365221d ('viridian: use viridian_map/unmap_guest_page() for reference tsc page')
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+Backported to 8.3.
+Backport notes:
+- Minor index changes.
+
+Backported-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+Signed-off-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+diff --git a/xen/arch/x86/hvm/viridian/time.c b/xen/arch/x86/hvm/viridian/time.c
+index 97caf0b..3c94fb0 100644
+--- a/xen/arch/x86/hvm/viridian/time.c
++++ b/xen/arch/x86/hvm/viridian/time.c
+@@ -109,8 +109,10 @@ static void time_ref_count_thaw(const struct domain *d)
+ 
+     trc->off = (int64_t)trc->val - trc_val(d, 0);
+ 
++    spin_lock(&vd->lock);
+     if ( vd->reference_tsc.msr.enabled )
+         update_reference_tsc(d, false);
++    spin_unlock(&vd->lock);
+ }
+ 
+ static uint64_t time_ref_count(const struct domain *d)
+@@ -332,6 +334,7 @@ int viridian_time_wrmsr(struct vcpu *v, uint32_t idx, uint64_t val)
+         if ( !(viridian_feature_mask(d) & HVMPV_reference_tsc) )
+             return X86EMUL_EXCEPTION;
+ 
++        spin_lock(&vd->lock);
+         viridian_unmap_guest_page(&vd->reference_tsc);
+         vd->reference_tsc.msr.raw = val;
+         viridian_dump_guest_page(v, "REFERENCE_TSC", &vd->reference_tsc);
+@@ -340,6 +343,7 @@ int viridian_time_wrmsr(struct vcpu *v, uint32_t idx, uint64_t val)
+             viridian_map_guest_page(d, &vd->reference_tsc);
+             update_reference_tsc(d, true);
+         }
++        spin_unlock(&vd->lock);
+         break;
+ 
+     case HV_X64_MSR_TIME_REF_COUNT:
+diff --git a/xen/arch/x86/hvm/viridian/viridian.c b/xen/arch/x86/hvm/viridian/viridian.c
+index 5c0effb..f22c65d 100644
+--- a/xen/arch/x86/hvm/viridian/viridian.c
++++ b/xen/arch/x86/hvm/viridian/viridian.c
+@@ -495,6 +495,8 @@ int viridian_domain_init(struct domain *d)
+     if ( !d->arch.hvm.viridian )
+         return -ENOMEM;
+ 
++    spin_lock_init(&d->arch.hvm.viridian->lock);
++
+     rc = viridian_synic_domain_init(d);
+     if ( rc )
+         goto fail;
+diff --git a/xen/arch/x86/include/asm/hvm/viridian.h b/xen/arch/x86/include/asm/hvm/viridian.h
+index 4c8ff6e..47c9d13 100644
+--- a/xen/arch/x86/include/asm/hvm/viridian.h
++++ b/xen/arch/x86/include/asm/hvm/viridian.h
+@@ -71,6 +71,7 @@ struct viridian_domain
+     DECLARE_BITMAP(hypercall_flags, _HCALL_nr);
+     struct viridian_time_ref_count time_ref_count;
+     struct viridian_page reference_tsc;
++    spinlock_t lock;
+ };
+ 
+ void cpuid_viridian_leaves(const struct vcpu *v, uint32_t leaf,

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -33,7 +33,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.5
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.5.tar.gz
@@ -301,6 +301,11 @@ Patch254: vtpm-ppi-acpi-dsm.patch
 Patch1000: 0001-xenguest-activate-nested-virt-when-requested.patch
 Patch1001: 0001-x86-hvmloader-select-xen-platform-pci-MMIO-BAR-UC-or.patch
 Patch1002: 0002-tools-golang-update-auto-generated-libxl-based-types.patch
+
+# XSA-472
+Patch1003: xsa472-1.patch
+Patch1004: xsa472-2.patch
+Patch1005: xsa472-3.patch
 
 ExclusiveArch: x86_64
 
@@ -1146,6 +1151,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Wed Aug 27 2025 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.17.5-15.3
+- Security fix for XSA-472 "Multiple vulnerabilities in the Viridian interface"
+
 * Fri Jul 11 2025 Anthoine Bourgeois <anthoine.bourgeois@vates.tech> - 4.17.5-15.2
 - Backport 22650d605462 "x86/hvmloader: select xen platform pci MMIO BAR UC or WB MTRR
   cache attributes"


### PR DESCRIPTION
Backport notes:

`xsa472-[123].patch`: Minor index changes

---

### Work Item Reference

_If this change is related to a Vates internal task or issue, please provide a work item reference. Otherwise, leave this blank._

XCPNG-1376

---

### Why should this change be accepted as an update to XCP-ng?

_Explain the motivation, problem being solved, or benefit to users or maintainers._

This is a backport for XSA-472 "Mutiple vulnerabilities in the Viridian interface".

---

### Release Notes

#### Explain the change for users

_Write a user-facing explanation which will serve as a basis for public announcements._
_Good release notes explain what changes, who is concerned, and how it affects them. It's not a technical changelog._

- Security fix for XSA-472 "Multiple vulnerabilities in the Viridian interface"

*(for the full announcement, see below)*

#### Do users or support need to be aware of anything specific related to the update?

_Any manual steps, changes to default behavior, compatibility issues, etc._

- [x] Yes
- [ ] No

_If yes, provide details._

===cut

**XCP-ng 8.3 security fix for XSA-472 "Multiple vulnerabilities in the Viridian interface"**

**Description**

Multiple vulnerabilities (CVE-2025-27466, CVE-2025-58142, CVE-2025-58143) were discovered in Xen's Viridian feature, which provides Hyper-V-compatible enlightenments for guest VMs, especially Windows.

These vulnerabilities could be used by guest VMs to hang, crash or compromise the host.

**Affected components**

XCP-ng 8.3 hosts running Xen versions older than 4.17.5-15.3 are affected.

These vulnerabilities are reachable from guest VMs with the `viridian_reference_tsc` or `viridian_stimer` platform features enabled. These settings are enabled by default on VMs based on Windows templates.

**Fix**

Update Xen to version 4.17.5-15.3 or later.

A workaround is available for those who can't patch: Not enabling the reference_tsc and stimer viridian extensions will avoid the issues.

For all VMs with Viridian enabled:

```
xe vm-param-set uuid=<vm uuid> platform:viridian_reference_tsc=false
xe vm-param-set uuid=<vm uuid> platform:viridian_stimer=false
```

===cut

---

### Testing and regression avoidance

#### What tests have you done?

_1. Regarding the change itself._

Not crashing with Viridian guests is the extent of my tests

_2. Regarding potential regressions._

```
pytest tests/misc -m "multi_vms and not flaky and not reboot" -k 'not test_live_migrate'
```

#### What tests in current test suites cover this change?

_1. Regarding the change itself._

main-multi-windows

_2. Regarding potential regressions._

main-multi-windows

#### What tests were or will be added to CI for this change? If none, explain why.

_1. Regarding the change itself._

N/A

_2. To ensure there are no regressions._

N/A

#### What other tests should reviewers or testers perform (after the build)?

_1. Regarding the change itself._

N/A

_2. Regarding potential regressions._

N/A

---

### Documentation

#### Should existing documentation be updated, or new documentation be added?

- [ ] Yes
- [x] No

_If yes, explain what needs to be updated or added, and where. If no, explain why._

This is a security fix. For XSA-472 in particular, no user documentation is needed.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add features that could be useful for Xen Orchestra?

- [ ] Yes
- [x] No

_If yes, describe which features and how._

N/A