### PR TITLE
Add SMBIOS 2.6 patch

### DIFF
--- a/SOURCES/0001-hvmloader-Add-a-temporary-way-of-forcing-legacy-SMBI.patch
+++ b/SOURCES/0001-hvmloader-Add-a-temporary-way-of-forcing-legacy-SMBI.patch
@@ -1,0 +1,71 @@
+From b4d42ec269684f374d28e34351e6046f9b6cd4f9 Mon Sep 17 00:00:00 2001
+Message-ID: <b4d42ec269684f374d28e34351e6046f9b6cd4f9.1762190698.git.teddy.astie@vates.tech>
+From: Teddy Astie <teddy.astie@vates.tech>
+Date: Mon, 3 Nov 2025 18:24:52 +0100
+Subject: [PATCH] hvmloader: Add a temporary way of forcing legacy SMBIOS
+
+Add a temporary option for reversing "Update to SMBIOS 2.6" if
+found problematic.
+
+Setting the guest xenstore variable "hvmloader/smbios/force_legacy"
+to 1 forces the legacy behavior.
+
+Signed-off-by: Teddy Astie <teddy.astie@vates.tech>
+---
+ tools/firmware/hvmloader/smbios.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/tools/firmware/hvmloader/smbios.c b/tools/firmware/hvmloader/smbios.c
+index 6647de79ea..7eb368702f 100644
+--- a/tools/firmware/hvmloader/smbios.c
++++ b/tools/firmware/hvmloader/smbios.c
+@@ -99,6 +99,7 @@ smbios_type_127_init(void *start);
+ 
+ static uint32_t *smbios_pt_addr = NULL;
+ static uint32_t smbios_pt_length = 0;
++static bool smbios_force_legacy = false;
+ 
+ static void
+ smbios_pt_init(void)
+@@ -311,6 +312,11 @@ hvm_write_smbios_tables(
+ 
+     xen_version_str[sizeof(xen_version_str)-1] = '\0';
+ 
++    smbios_force_legacy = strtoll(xenstore_read("hvmloader/smbios/force_legacy", "0"),
++                                  NULL, 0);
++    if ( smbios_force_legacy )
++        printf("Forcing legacy SMBIOS table version !\n");
++
+     /* scratch_start is a safe large memory area for scratch. */
+     len = write_smbios_tables((void *)ep, (void *)scratch_start,
+                               hvm_info->nr_vcpus, get_memsize(),
+@@ -352,7 +358,7 @@ smbios_entry_point_init(void *start,
+     memcpy(ep->anchor_string, "_SM_", 4);
+     ep->length = 0x1f;
+     ep->smbios_major_version = 2;
+-    ep->smbios_minor_version = 6;
++    ep->smbios_minor_version = smbios_force_legacy ? 4 : 6;
+     ep->max_structure_size = max_structure_size;
+     ep->entry_point_revision = 0;
+     memcpy(ep->intermediate_anchor_string, "_DMI_", 5);
+@@ -462,6 +468,9 @@ smbios_type_1_init(void *start, const char *xen_version,
+     p->version_str = 3;
+     p->serial_number_str = 4;
+ 
++    if ( smbios_force_legacy )
++        memcpy(p->uuid, uuid, 16);
++    else {
+     /*
+      * Xen toolstack uses big endian UUIDs, however SMBIOS specs uses another
+      * representation specified in SMBIOS >= 2.6) has the first 3 components
+@@ -478,6 +487,7 @@ smbios_type_1_init(void *start, const char *xen_version,
+     p->uuid[7] = uuid[6];
+     /* Rest */
+     memcpy(p->uuid + 8, uuid + 8, 8);
++    }
+ 
+     p->wake_up_type = 0x06; /* power switch */
+     p->sku_str = 0;
+-- 
+2.51.2
+

--- a/SOURCES/0001-hvmloader-Update-to-SMBIOS-2.6.patch
+++ b/SOURCES/0001-hvmloader-Update-to-SMBIOS-2.6.patch
@@ -1,0 +1,75 @@
+From 05c716c9f66cedcd9392da4a252a2da1137bd227 Mon Sep 17 00:00:00 2001
+Message-ID: <05c716c9f66cedcd9392da4a252a2da1137bd227.1761571354.git.teddy.astie@vates.tech>
+From: Teddy Astie <teddy.astie@vates.tech>
+Date: Fri, 22 Aug 2025 15:43:32 +0200
+Subject: [PATCH] hvmloader: Update to SMBIOS 2.6
+
+Currently, hvmloader uses SMBIOS 2.4, however, when using OVMF, the
+SMBIOS is patched to 2.8, which has clarified the UUID format (as GUID).
+
+In Linux, if the SMBIOS version is >= 2.6, the GUID format is used, else
+(undefined as per SMBIOS spec), big endian is used (used by Xen). Therefore,
+you have a endian mismatch causing the UUIDs to mismatch in the guest.
+
+$ cat /sys/hypervisor/uuid
+e865e63f-3d30-4f0b-83e0-8fdfc1e30eb7
+$ cat /sys/devices/virtual/dmi/id/product_uuid
+3fe665e8-303d-0b4f-83e0-8fdfc1e30eb7
+$ cat /sys/devices/virtual/dmi/id/product_serial
+e865e63f-3d30-4f0b-83e0-8fdfc1e30eb7
+
+This patch updates the SMBIOS version from 2.4 to 2.6 and does the appropriate
+modifications of the table. This effectively fix this endianness mismatch with
+OVMF; while the UUID displayed by Linux is still the same for SeaBIOS.
+
+Fixes: c683914ef913 ("Add code to generate SMBIOS tables to hvmloader.")
+(SMBIOS versions before 2.6 has a ill-defined UUID definition)
+Signed-off-by: Teddy Astie <teddy.astie@vates.tech>
+---
+Backport notes: Only pick SMBIOS version and UUID changes.
+
+ tools/firmware/hvmloader/smbios.c | 21 ++++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/tools/firmware/hvmloader/smbios.c b/tools/firmware/hvmloader/smbios.c
+index 97a054e9e3..6647de79ea 100644
+--- a/tools/firmware/hvmloader/smbios.c
++++ b/tools/firmware/hvmloader/smbios.c
+@@ -352,7 +352,7 @@ smbios_entry_point_init(void *start,
+     memcpy(ep->anchor_string, "_SM_", 4);
+     ep->length = 0x1f;
+     ep->smbios_major_version = 2;
+-    ep->smbios_minor_version = 4;
++    ep->smbios_minor_version = 6;
+     ep->max_structure_size = max_structure_size;
+     ep->entry_point_revision = 0;
+     memcpy(ep->intermediate_anchor_string, "_DMI_", 5);
+@@ -461,8 +461,23 @@ smbios_type_1_init(void *start, const char *xen_version,
+     p->product_name_str = 2;
+     p->version_str = 3;
+     p->serial_number_str = 4;
+-    
+-    memcpy(p->uuid, uuid, 16);
++
++    /*
++     * Xen toolstack uses big endian UUIDs, however SMBIOS specs uses another
++     * representation specified in SMBIOS >= 2.6) has the first 3 components
++     * appearing as being little endian and the rest as still being big endian.
++     */
++    /* First component */
++    for ( unsigned int i = 0; i < 4; i++ )
++        p->uuid[i] = uuid[4 - i - 1];
++    /* Second component */
++    p->uuid[4] = uuid[5];
++    p->uuid[5] = uuid[4];
++    /* Third component */
++    p->uuid[6] = uuid[7];
++    p->uuid[7] = uuid[6];
++    /* Rest */
++    memcpy(p->uuid + 8, uuid + 8, 8);
+ 
+     p->wake_up_type = 0x06; /* power switch */
+     p->sku_str = 0;
+-- 
+2.51.1
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -33,7 +33,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.5
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.5.tar.gz
@@ -326,6 +326,9 @@ Patch1001: 0002-tools-golang-update-auto-generated-libxl-based-types.patch
 
 Patch1002: xsa475-1.patch
 Patch1003: xsa475-2.patch
+
+# SMBIOS 2.6 patches
+Patch1004: 0001-hvmloader-Update-to-SMBIOS-2.6.patch
 
 ExclusiveArch: x86_64
 
@@ -1173,6 +1176,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Mon Oct 27 2025 Teddy Astie <teddy.astie@vates.tech> - 4.17.5-20.3
+- Update SMBIOS version to 2.6 and fix UUID endianness issues.
+
 * Tue Oct 21 2025 Teddy Astie <teddy.astie@vates.tech> - 4.17.5-20.2
 - Fixes for XSA-475 CVE-2025-58147 CVE-2025-58148
 

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -329,6 +329,7 @@ Patch1003: xsa475-2.patch
 
 # SMBIOS 2.6 patches
 Patch1004: 0001-hvmloader-Update-to-SMBIOS-2.6.patch
+Patch1005: 0001-hvmloader-Add-a-temporary-way-of-forcing-legacy-SMBI.patch
 
 ExclusiveArch: x86_64
 
@@ -1176,8 +1177,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
-* Mon Oct 27 2025 Teddy Astie <teddy.astie@vates.tech> - 4.17.5-20.3
+* Mon Nov 03 2025 Teddy Astie <teddy.astie@vates.tech> - 4.17.5-20.3
 - Update SMBIOS version to 2.6 and fix UUID endianness issues.
+- Add temporary parameter to force legacy SMBIOS version and UUID behavior.
 
 * Tue Oct 21 2025 Teddy Astie <teddy.astie@vates.tech> - 4.17.5-20.2
 - Fixes for XSA-475 CVE-2025-58147 CVE-2025-58148


### PR DESCRIPTION
Superseedes https://github.com/xcp-ng-rpms/xen/pull/68

This changes updates by default the SMBIOS to 2.6 and writes the guest UUID as GUID (according to the SMBIOS 2.6+ spec).
It is expected to fix various issues guest UUID (from XAPI/XO) mismatching the one SMBIOS tables, notably :
* UUIDs read from Windows (I assume they are considered as GUID); both BIOS and UEFI
* UUIDs read from Linux using dmidecode or /sys/devices/virtual/dmi/id/product_uuid in UEFI mode

Expected to fix https://github.com/vatesfr/xenorchestra-cloud-controller-manager/issues/10 and third-party tools that relies on the SMBIOS UUID matching the Xen Orchestra/XAPI one (e.g Veeam).