### PR TITLE
Security fix "xen/mm: don't unconditionally clear _PGC_need_scrub in alloc_heap_pages()"

### DIFF
--- a/SOURCES/0001-xen-mm-don-t-unconditionally-clear-_PGC_need_scrub-i.patch
+++ b/SOURCES/0001-xen-mm-don-t-unconditionally-clear-_PGC_need_scrub-i.patch
@@ -1,0 +1,154 @@
+From c2ebfad7226fd0b7caa328aa99c6dfd1def75e01 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Thu, 19 Mar 2026 08:49:31 +0100
+Subject: [PATCH] xen/mm: don't unconditionally clear _PGC_need_scrub in
+ alloc_heap_pages()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+alloc_heap_pages() will unconditionally clear _PGC_need_scrub, even when
+MEMF_no_scrub is requested.  This is kind of expected as otherwise some
+callers will assert on seeing non-expected flags set on the count_info
+field.
+
+Introduce a new version of alloc_domheap_pages() that returns pages with
+extra flags (currently only _PGC_need_scrub) set.  This new interface is
+only used by populate_physmap() that knows how to deal with that flag.
+Other callers are strictly kept using alloc_domheap_pages().
+
+This fixes returning dirty pages from alloc_domheap_pages() without the
+_PGC_need_scrub bit set for populate_physmap() to consume.
+
+Fixes: 83a784a15b47 ("xen/mm: allow deferred scrub of physmap populate allocated pages")
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+diff --git a/xen/common/memory.c b/xen/common/memory.c
+index b60ece8583c6..3e04e28640f1 100644
+--- a/xen/common/memory.c
++++ b/xen/common/memory.c
+@@ -350,7 +350,8 @@ static void populate_physmap(struct memop_args *a)
+                                               &scrub_start);
+ 
+                 if ( !page )
+-                    page = alloc_domheap_pages(d, a->extent_order, memflags);
++                    page = alloc_domheap_pages_flags(d, a->extent_order,
++                                                     memflags, false);
+ 
+                 if ( unlikely(!page) )
+                 {
+diff --git a/xen/common/page_alloc.c b/xen/common/page_alloc.c
+index ebd88b7ce88f..dbe6486d77e6 100644
+--- a/xen/common/page_alloc.c
++++ b/xen/common/page_alloc.c
+@@ -923,7 +923,7 @@ static struct page_info *get_free_buddy(unsigned int zone_lo,
+ static struct page_info *alloc_heap_pages(
+     unsigned int zone_lo, unsigned int zone_hi,
+     unsigned int order, unsigned int memflags,
+-    struct domain *d)
++    struct domain *d, bool clear_scrub)
+ {
+     nodeid_t node;
+     unsigned int i, buddy_order, zone, first_dirty;
+@@ -1040,11 +1040,14 @@ static struct page_info *alloc_heap_pages(
+     {
+         for ( i = 0; i < (1U << order); i++ )
+         {
+-            if ( test_and_clear_bit(_PGC_need_scrub, &pg[i].count_info) )
++            if ( test_bit(_PGC_need_scrub, &pg[i].count_info) )
+             {
+                 if ( !(memflags & MEMF_no_scrub) )
+                     scrub_one_page(&pg[i]);
+ 
++                if ( !(memflags & MEMF_no_scrub) || clear_scrub )
++                    __clear_bit(_PGC_need_scrub, &pg[i].count_info);
++
+                 dirty_cnt++;
+             }
+             else if ( !(memflags & MEMF_no_scrub) )
+@@ -2221,7 +2224,7 @@ void *alloc_xenheap_pages(unsigned int order, unsigned int memflags)
+     ASSERT_ALLOC_CONTEXT();
+ 
+     pg = alloc_heap_pages(MEMZONE_XEN, MEMZONE_XEN,
+-                          order, memflags | MEMF_no_scrub, NULL);
++                          order, memflags | MEMF_no_scrub, NULL, true);
+     if ( unlikely(pg == NULL) )
+         return NULL;
+ 
+@@ -2344,7 +2347,8 @@ int assign_pages(
+ 
+         for ( i = 0; i < nr; i++ )
+         {
+-            ASSERT(!(pg[i].count_info & ~(PGC_extra | PGC_static)));
++            ASSERT(!(pg[i].count_info &
++                     ~(PGC_extra | PGC_static | PGC_need_scrub)));
+             if ( pg[i].count_info & PGC_extra )
+                 extra_pages++;
+         }
+@@ -2421,8 +2425,9 @@ int assign_page(struct page_info *pg, unsigned int order, struct domain *d,
+     return assign_pages(pg, 1U << order, d, memflags);
+ }
+ 
+-struct page_info *alloc_domheap_pages(
+-    struct domain *d, unsigned int order, unsigned int memflags)
++struct page_info *alloc_domheap_pages_flags(
++    struct domain *d, unsigned int order, unsigned int memflags,
++    bool clear_scrub)
+ {
+     struct page_info *pg = NULL;
+     unsigned int bits = memflags >> _MEMF_bits, zone_hi = NR_ZONES - 1;
+@@ -2442,12 +2447,13 @@ struct page_info *alloc_domheap_pages(
+     if ( !dma_bitsize )
+         memflags &= ~MEMF_no_dma;
+     else if ( (dma_zone = bits_to_zone(dma_bitsize)) < zone_hi )
+-        pg = alloc_heap_pages(dma_zone + 1, zone_hi, order, memflags, d);
++        pg = alloc_heap_pages(dma_zone + 1, zone_hi, order, memflags, d,
++                              clear_scrub);
+ 
+     if ( (pg == NULL) &&
+          ((memflags & MEMF_no_dma) ||
+           ((pg = alloc_heap_pages(MEMZONE_XEN + 1, zone_hi, order,
+-                                  memflags, d)) == NULL)) )
++                                  memflags, d, clear_scrub)) == NULL)) )
+          return NULL;
+ 
+     if ( d && !(memflags & MEMF_no_owner) )
+@@ -2458,8 +2464,9 @@ struct page_info *alloc_domheap_pages(
+ 
+             for ( i = 0; i < (1ul << order); i++ )
+             {
+-                ASSERT(!pg[i].count_info);
+-                pg[i].count_info = PGC_extra;
++                ASSERT(!(pg[i].count_info & ~(clear_scrub ? 0
++                                                          : PGC_need_scrub)));
++                pg[i].count_info |= PGC_extra;
+             }
+         }
+         if ( assign_page(pg, order, d, memflags) )
+diff --git a/xen/include/xen/mm.h b/xen/include/xen/mm.h
+index 48931d57c46b..3a45126cbbbc 100644
+--- a/xen/include/xen/mm.h
++++ b/xen/include/xen/mm.h
+@@ -130,8 +130,21 @@ void get_outstanding_claims(uint64_t *free_pages, uint64_t *outstanding_pages);
+ 
+ /* Domain suballocator. These functions are *not* interrupt-safe.*/
+ void init_domheap_pages(paddr_t ps, paddr_t pe);
+-struct page_info *alloc_domheap_pages(
+-    struct domain *d, unsigned int order, unsigned int memflags);
++
++/*
++ * Direct callers of alloc_domheap_pages_flags() must sanitize the contents
++ * of the count_info field to ensure no unexpected flags are leaked.
++ */
++struct page_info *alloc_domheap_pages_flags(
++    struct domain *d, unsigned int order, unsigned int memflags,
++    bool clear_scrub);
++
++static inline struct page_info *alloc_domheap_pages(
++    struct domain *d, unsigned int order, unsigned int memflags)
++{
++    return alloc_domheap_pages_flags(d, order, memflags, true);
++}
++
+ void free_domheap_pages(struct page_info *pg, unsigned int order);
+ unsigned long avail_domheap_pages_region(
+     unsigned int node, unsigned int min_width, unsigned int max_width);

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -31,7 +31,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.6
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.6.tar.gz
@@ -296,6 +296,7 @@ Patch252: vtpm-ppi-acpi-dsm.patch
 # XCP-ng patches
 Patch1000: 0001-xenguest-activate-nested-virt-when-requested.patch
 Patch1001: 0002-tools-golang-update-auto-generated-libxl-based-types.patch
+Patch1002: 0001-xen-mm-don-t-unconditionally-clear-_PGC_need_scrub-i.patch
 
 ExclusiveArch: x86_64
 
@@ -1143,6 +1144,10 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Tue Mar 24 2026 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.17.6-5.2
+- Security fix "xen/mm: don't unconditionally clear _PGC_need_scrub in
+  alloc_heap_pages()"
+
 * Tue Mar 17 2026 Lucas Pottier <lucas.pottier@vates.tech> - 4.17.6-5.1
 - Sync with XenServer 4.17.6-5
 - Use xsa480.patch provided by XenServer


### PR DESCRIPTION
### Work Item Reference

_If this change is related to a Vates internal task or issue, please provide a work item reference. Otherwise, leave this blank._

XCPNG-3093

---

### Why should this change be accepted as an update to XCP-ng?

_Explain the motivation, problem being solved, or benefit to users or maintainers._

Integrate security fix from XenServer "xen/mm: don't unconditionally clear _PGC_need_scrub in alloc_heap_pages()"

The fix targets the `populate_physmap` memory allocation operation during domain creation.

[83a784a15b47](https://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=83a784a15b47;hp=cbb484d008e1c7982e0038b1331ff59f94201be5) ("xen/mm: allow deferred scrub of physmap populate allocated pages") optimized the domain creation process by deferring the page scrubbing process. The deferral is implemented by calling alloc_heap_pages(MEMF_no_scrub) to avoid starting the scrub operation during that call.

Upstream Xen clears the per-page PGC_need_scrub bit only if the MEMF_no_scrub operation flag is not set in the call to alloc_heap_pages; as a result, calls specifying MEMF_no_scrub will (correctly) not clear PGC_need_scrub.

However, its backport to the XenServer version of Xen (`backport-83a784a15b47.patch`) uses a completely different logic, where MEMF_no_scrub is checked after PGC_need_scrub is cleared. This means alloc_heap_pages calls with MEMF_no_scrub specified will clear PGC_need_scrub, despite never actually scrubbing the page. The consequence is leakage of memory contents of the hypervisor and other domains to the domain being created.

This patch clears PGC_need_scrub only after checking MEMF_no_scrub, and only outside of the initial populate_physmap during domain creation, thus maintaining the deferral.

Truth table for reference:

current PGC_need_scrub | MEMF_no_scrub | clear_scrub (new patch) | actually scrub page | old clear PGC_need_scrub | new clear PGC_need_scrub
-- | -- | -- | -- | -- | --
FALSE | FALSE | FALSE | FALSE | FALSE | FALSE
FALSE | FALSE | TRUE | FALSE | FALSE | FALSE
TRUE | FALSE | FALSE | TRUE | TRUE | TRUE
TRUE | FALSE | TRUE | TRUE | TRUE | TRUE
FALSE | TRUE | FALSE | FALSE | FALSE | FALSE
FALSE | TRUE | TRUE | FALSE | FALSE | FALSE
**TRUE** | **TRUE** | **FALSE** | **FALSE** | **TRUE** | **FALSE**
TRUE | TRUE | TRUE | FALSE | TRUE | TRUE

---

### Release Notes

#### Explain the change for users

_Write a user-facing explanation which will serve as a basis for public announcements._
_Good release notes explain what changes, who is concerned, and how it affects them. It's not a technical changelog._

Fix a security issue causing leakage of hypervisor memory contents to guests

#### Content for VSA

The Xen hypervisor in XCP-ng contains a bug where the hypervisor failed to sanitize memory pages before handing them over to a new guest during its creation.

The result is leakage of memory contents of previous guests (e.g. shut-down/crashed guests) to newly-created ones, potentially leading to privilege escalation depending on the secrets leaked.

xen-4.17.6-4.1.xcpng8.3 and later are affected.

Updating to xen-4.17.6-5.2.xcpng8.3 or later fixes the issue.

There are no known mitigations.

This issue was reported and fixed by Roger Pau Monné of XenServer.

#### Do users or support need to be aware of anything specific related to the update?

_Any manual steps, changes to default behavior, compatibility issues, etc._

- [ ] Yes
- [x] No

_If yes, provide details._

N/A

---

### Testing and regression avoidance

#### What tests have you done?

_1. Regarding the change itself._

```
pytest tests/misc -m "multi_vms and not flaky and not reboot and not hostA2 and not hostB1"
pytest tests/xen -m "not flaky and not hostA2 and not hostB1" -k "not TestXtf and not TestXenPlatformPciBarUc"
```

_2. Regarding potential regressions._

Same as above

#### What tests in current test suites cover this change?

_1. Regarding the change itself._

Usual main tests

_2. Regarding potential regressions._

Same as above

#### What tests were or will be added to CI for this change? If none, explain why.

_1. Regarding the change itself._

N/A

_2. To ensure there are no regressions._

N/A

#### What other tests should reviewers or testers perform (after the build)?

_1. Regarding the change itself._

N/A

_2. Regarding potential regressions._

N/A

---

### Documentation

#### Should existing documentation be updated, or new documentation be added?

- [x] Yes
- [ ] No

_If yes, explain what needs to be updated or added, and where. If no, explain why._

VSA docs

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add features that could be useful for Xen Orchestra?

- [ ] Yes
- [x] No

_If yes, describe which features and how._

N/A