### PR TITLE
Enable EFI_SET_VIRTUAL_ADDRESS_MAP by default

### DIFF
--- a/SOURCES/0001-efi-Enable-EFI_SET_VIRTUAL_ADDRESS_MAP-by-default.patch
+++ b/SOURCES/0001-efi-Enable-EFI_SET_VIRTUAL_ADDRESS_MAP-by-default.patch
@@ -1,0 +1,74 @@
+From 93eea4a654af19b47f0bd33bebf54e36eda27572 Mon Sep 17 00:00:00 2001
+Message-ID: <93eea4a654af19b47f0bd33bebf54e36eda27572.1775724164.git.teddy.astie@vates.tech>
+From: Teddy Astie <teddy.astie@vates.tech>
+Date: Mon, 23 Mar 2026 11:16:45 +0100
+Subject: [PATCH] efi: Enable EFI_SET_VIRTUAL_ADDRESS_MAP by default
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Many machines fails to boot if this option is disabled.
+It's off by default as it was deemed too risky for being enabled
+by default late in the Xen 4.13 cycle, but found out to be safe.
+As there are no known drawback by having this option on, enable
+it by default.
+
+Signed-off-by: Teddy Astie <teddy.astie@vates.tech>
+Acked-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Upstream: https://gitlab.com/xen-project/xen/-/commit/05dbc316f6b72e8fe03fc5a8792bec22078a48be
+Backport: Apply the change to buildconfigs
+---
+ buildconfigs/config-debug   | 2 +-
+ buildconfigs/config-release | 2 +-
+ xen/common/Kconfig          | 3 +--
+ 3 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/buildconfigs/config-debug b/buildconfigs/config-debug
+index 50c96881e6..604d7940a6 100644
+--- a/buildconfigs/config-debug
++++ b/buildconfigs/config-debug
+@@ -85,7 +85,7 @@ CONFIG_HYPFS=y
+ CONFIG_HYPFS_CONFIG=y
+ CONFIG_IOREQ_SERVER=y
+ CONFIG_KEXEC=y
+-# CONFIG_EFI_SET_VIRTUAL_ADDRESS_MAP is not set
++CONFIG_EFI_SET_VIRTUAL_ADDRESS_MAP=y
+ # CONFIG_XENOPROF is not set
+ CONFIG_XSM=y
+ # CONFIG_XSM_FLASK is not set
+diff --git a/buildconfigs/config-release b/buildconfigs/config-release
+index c808a70869..54ddbc3654 100644
+--- a/buildconfigs/config-release
++++ b/buildconfigs/config-release
+@@ -85,7 +85,7 @@ CONFIG_HYPFS=y
+ CONFIG_HYPFS_CONFIG=y
+ CONFIG_IOREQ_SERVER=y
+ CONFIG_KEXEC=y
+-# CONFIG_EFI_SET_VIRTUAL_ADDRESS_MAP is not set
++CONFIG_EFI_SET_VIRTUAL_ADDRESS_MAP=y
+ # CONFIG_XENOPROF is not set
+ CONFIG_XSM=y
+ # CONFIG_XSM_FLASK is not set
+diff --git a/xen/common/Kconfig b/xen/common/Kconfig
+index 4d73c65cd3..dd4ec948ce 100644
+--- a/xen/common/Kconfig
++++ b/xen/common/Kconfig
+@@ -306,14 +306,13 @@ config KEXEC
+ 
+ config EFI_SET_VIRTUAL_ADDRESS_MAP
+     bool "EFI: call SetVirtualAddressMap()" if EXPERT
++    default y
+     ---help---
+       Call EFI SetVirtualAddressMap() runtime service to setup memory map for
+       further runtime services. According to UEFI spec, it isn't strictly
+       necessary, but many UEFI implementations misbehave when this call is
+       missing.
+ 
+-      If unsure, say N.
+-
+ config XENOPROF
+ 	def_bool y
+ 	prompt "Xen Oprofile Support" if EXPERT
+-- 
+2.53.0
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -31,7 +31,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.6
-Release: %{?xsrel}.3%{?dist}
+Release: %{?xsrel}.4%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.6.tar.gz
@@ -343,6 +343,9 @@ Patch1023: dts-0004-x86-platform-Adjust-temperature-sensors-MSRs.patch
 Patch1024: dts-0005-libxc-Report-EINVAL-in-invalid-xc_resource_op-use.patch
 Patch1025: dts-0006-xenpm-Use-EXIT_-SUCCESS-FAILURE-instead-of-errno-as-.patch
 Patch1026: dts-0007-xenpm-Add-get-core-temp-subcommand.patch
+
+# EFI_SET_VIRTUAL_ADDRESS_MAP
+Patch1027: 0001-efi-Enable-EFI_SET_VIRTUAL_ADDRESS_MAP-by-default.patch
 
 ExclusiveArch: x86_64
 
@@ -1190,6 +1193,10 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Thu Jun 18 2026 Teddy Astie <teddy.astie@vates.tech> - 4.17.6-9.4
+- Enable EFI_SET_VIRTUAL_ADDRESS_MAP by default to fix boot failure on
+  some systems with UEFI.
+
 * Thu Jun 11 2026 Teddy Astie <teddy.astie@vates.tech> - 4.17.6-9.3
 - Add support for Intel Digital Thermal Sensors.
 - Introduce xenpm get-core-temp command.


### PR DESCRIPTION
```
Many machines fails to boot if this option is disabled.
It's off by default as it was deemed too risky for being enabled by default late in the Xen 4.13 cycle, but found out to be safe.
As there are no known drawback by having this option on, enable it by default.
```

---

### Work Item Reference

_If this change is related to a Vates internal task or issue, please provide a work item reference. Otherwise, leave this blank._

XCPNG-2784

---

### Why should this change be accepted as an update to XCP-ng?

_Explain the motivation, problem being solved, or benefit to users or maintainers._

Numerous systems fail to boot XCP-ng 8.3 (with UEFI) without this patch.

---

### Release Notes

#### Explain the change for users

_Write a user-facing explanation which will serve as a basis for public announcements._
_Good release notes explain what changes, who is concerned, and how it affects them. It's not a technical changelog._

Fix boot failure on some UEFI systems.

#### Do users or support need to be aware of anything specific related to the update?

_Any manual steps, changes to default behavior, compatibility issues, etc._

- [ ] Yes
- [X] No

_If yes, provide details._

---

### Testing and regression avoidance

#### What tests have you done?

_1. Regarding the change itself._

Xen upstream requires this patch or the option to be enabled for it to boot on some systems.

It's required for Xen to boot on a HP EliteDesk 800 G1 SFF.

_2. Regarding potential regressions._

Very unlikely. This would mean the firmware fails to boot on most other operating system to begin with.

kexec/crashdump has been manually tested and still works with this change (one of the main concerns).

#### What tests in current test suites cover this change?

_1. Regarding the change itself._

N/A

_2. Regarding potential regressions._

N/A

#### What tests were or will be added to CI for this change? If none, explain why.

_1. Regarding the change itself._

N/A

_2. To ensure there are no regressions._

N/A

#### What other tests should reviewers or testers perform (after the build)?

_1. Regarding the change itself._

Assuming a updated iso with this, if they had troubles installing XCP-ng, they can try to see if this fixes anything.

_2. Regarding potential regressions._

N/A

---

### Documentation

#### Should existing documentation be updated, or new documentation be added?

- [ ] Yes
- [X] No

_If yes, explain what needs to be updated or added, and where. If no, explain why._

We need a new iso file to make the change relevant. Otherwise, people wouldn't be able to boot on a installer with a patched Xen.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add features that could be useful for Xen Orchestra?

- [ ] Yes
- [X] No

_If yes, describe which features and how._
