### PR TITLE
Security fixes for XSA-483, XSA-486 and XSA-488.

### DIFF
--- a/SOURCES/x86-amd-Mitigate-AMD-SN-7053-FP-DSS.patch
+++ b/SOURCES/x86-amd-Mitigate-AMD-SN-7053-FP-DSS.patch
@@ -1,0 +1,95 @@
+From 2f14ed584c5432a2e99189a90b86aea33c6e1e95 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Tue, 21 Apr 2026 09:36:18 +0200
+Subject: [PATCH] x86/amd: Mitigate AMD-SN-7053 / FP-DSS
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This is XSA-488 / CVE-2025-54505
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+
+Backport from xsa488-4.17.patch to 4.17.6-6.1.
+
+6372a05b06cb ("x86/amd: Fix race editing DE_CFG") introduced only context
+conflicst: new function zenbleed_use_chickenbit() is part of the context
+now, as well as call to amd_init_de_cfg() in init_amd().
+
+Signed-off-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ xen/arch/x86/cpu/amd.c               | 37 ++++++++++++++++++++++++++++
+ xen/arch/x86/include/asm/msr-index.h |  1 +
+ 2 files changed, 38 insertions(+)
+
+diff --git a/xen/arch/x86/cpu/amd.c b/xen/arch/x86/cpu/amd.c
+index 7b4315c91091..af9e909c7bdd 100644
+--- a/xen/arch/x86/cpu/amd.c
++++ b/xen/arch/x86/cpu/amd.c
+@@ -873,6 +873,42 @@ static void cf_check fam17_disable_c6(void *arg)
+ 	wrmsrl(MSR_AMD_CSTATE_CFG, val & mask);
+ }
+ 
++static void amd_init_fp_cfg(const struct cpuinfo_x86 *c)
++{
++    uint64_t val, new = 0;
++
++    /* If virtualised, we won't have mutable access even if we can read it. */
++    if ( cpu_has_hypervisor )
++        return;
++
++    /*
++     * On Zen1, mitigate SB-7053 / FP-DSS Floating Point Divider State
++     * Sampling by setting bit 9 as instructed.
++     */
++    if ( c->x86 == 0x17 && is_zen1_uarch() )
++        new |= 1 << 9;
++
++    /*
++     * Avoid reading FP_CFG if we don't intend to change anything.  The
++     * register doesn't exist on all families.
++     */
++    if ( !new )
++        return;
++
++    rdmsrl(MSR_AMD64_FP_CFG, val);
++
++    if ( (val & new) == new )
++        return;
++
++    /*
++     * FP_CFG is a Core-scoped MSR, and this write is racy.  However, both
++     * threads calculate the new value from state which expected to be
++     * consistent across CPUs and unrelated to the old value, so the result
++     * should be consistent.
++     */
++    wrmsrl(MSR_AMD64_FP_CFG, val | new);
++}
++
+ static bool zenbleed_use_chickenbit(void)
+ {
+     unsigned int curr_rev;
+@@ -1020,6 +1056,7 @@ static void cf_check init_amd(struct cpuinfo_x86 *c)
+ 
+ 	unsigned long long value;
+ 
++	amd_init_fp_cfg(c);
+ 	amd_init_de_cfg(c);
+ 
+ 	if (c == &boot_cpu_data)
+diff --git a/xen/arch/x86/include/asm/msr-index.h b/xen/arch/x86/include/asm/msr-index.h
+index db602fdbfeeb..a9d33250ba0c 100644
+--- a/xen/arch/x86/include/asm/msr-index.h
++++ b/xen/arch/x86/include/asm/msr-index.h
+@@ -392,6 +392,7 @@
+ #define MSR_AMD64_LS_CFG		0xc0011020
+ #define MSR_AMD64_IC_CFG		0xc0011021
+ #define MSR_AMD64_DC_CFG		0xc0011022
++#define MSR_AMD64_FP_CFG		0xc0011028
+ #define MSR_AMD64_DE_CFG		0xc0011029
+ #define AMD64_DE_CFG_LFENCE_SERIALISE	(_AC(1, ULL) << 1)
+ #define MSR_AMD64_EX_CFG		0xc001102c
+-- 
+2.43.0
+

--- a/SOURCES/xsa483-4.17.patch
+++ b/SOURCES/xsa483-4.17.patch
@@ -1,0 +1,30 @@
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Subject: tools/oxenstored: Reset quota when resetting permissions
+
+The quota object contains both limits and the current node usage counts.
+
+When a domain is torn down, the node data itself is cleaned up but the node
+usage counts are not.  A later domain reusing the same domid can create fewer
+nodes before being deemed to be over quota.
+
+Reset the count when the node permissions are cleaned up.
+
+This is XSA-483 / CVE-2026-23556.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+diff --git a/tools/ocaml/xenstored/store.ml b/tools/ocaml/xenstored/store.ml
+index 5dd965db151f..c099a2eae68a 100644
+--- a/tools/ocaml/xenstored/store.ml
++++ b/tools/ocaml/xenstored/store.ml
+@@ -465,7 +465,8 @@ let reset_permissions store domid =
+ 			if perms <> node.perms then
+ 				Logging.debug "store|node" "Changed permissions for node %s" (Node.get_name node);
+ 			Some { node with Node.perms }
+-	) store.root
++	) store.root;
++	store.quota <- Quota.del store.quota domid
+ 
+ type ops = {
+ 	store: t;

--- a/SOURCES/xsa486-4.18.patch
+++ b/SOURCES/xsa486-4.18.patch
@@ -1,0 +1,181 @@
+From: Jan Beulich <jbeulich@suse.com>
+Subject: gnttab: split gnttab_map_frame()
+
+If a domain tries to map status frames in parallel to switching grant
+table version from 2 to 1, the mapping operation may put in place P2M
+entries referencing MFNs which gnttab_unpopulate_status_frames() is in the
+process of freeing.
+
+Ideally we would refcount pages when entered into P2M tables, but that's a
+significant change. Extend the grant-table-locked region instead in
+xenmem_add_to_physmap_one() (being the sole caller of gnttab_map_frame()),
+such that a race with gnttab_unpopulate_status_frames() is no longer
+possible.
+
+This is XSA-486 / CVE-2026-23558.
+
+Fixes: 5ce8fafa947c ("Dynamic grant-table sizing")
+Fixes: a98dc13703e0 ("Introduce a grant_entry_v2 structure")
+Reported-by: Rafal Wojtczuk <rafal.wojtczuk@7bulls.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+
+--- a/xen/arch/arm/mm.c
++++ b/xen/arch/arm/mm.c
+@@ -1372,12 +1372,10 @@ int xenmem_add_to_physmap_one(
+     switch ( space )
+     {
+     case XENMAPSPACE_grant_table:
+-        rc = gnttab_map_frame(d, idx, gfn, &mfn);
++        rc = gnttab_map_frame_begin(d, idx, gfn, &mfn);
+         if ( rc )
+             return rc;
+ 
+-        /* Need to take care of the reference obtained in gnttab_map_frame(). */
+-        page = mfn_to_page(mfn);
+         t = p2m_ram_rw;
+ 
+         break;
+@@ -1479,10 +1477,23 @@ int xenmem_add_to_physmap_one(
+      * to drop the reference we took earlier. In all other cases we need to
+      * drop any reference we took earlier (perhaps indirectly).
+      */
+-    if ( space == XENMAPSPACE_gmfn_foreign ? rc : page != NULL )
++    switch ( space )
+     {
++    default:
++        if ( page )
++            put_page(page);
++        break;
++
++    case XENMAPSPACE_grant_table:
++        gnttab_map_frame_end(d, mfn);
++        break;
++
++    case XENMAPSPACE_gmfn_foreign:
++        if ( !rc )
++            break;
+         ASSERT(page != NULL);
+         put_page(page);
++        break;
+     }
+ 
+     return rc;
+--- a/xen/arch/x86/mm/p2m.c
++++ b/xen/arch/x86/mm/p2m.c
+@@ -2446,11 +2446,9 @@ int xenmem_add_to_physmap_one(
+         break;
+ 
+     case XENMAPSPACE_grant_table:
+-        rc = gnttab_map_frame(d, idx, gpfn, &mfn);
++        rc = gnttab_map_frame_begin(d, idx, gpfn, &mfn);
+         if ( rc )
+             return rc;
+-        /* Need to take care of the reference obtained in gnttab_map_frame(). */
+-        page = mfn_to_page(mfn);
+         break;
+ 
+     case XENMAPSPACE_gmfn:
+@@ -2526,19 +2524,28 @@ int xenmem_add_to_physmap_one(
+     put_gfn(d, gfn_x(gpfn));
+ 
+  put_both:
+-    /*
+-     * In the XENMAPSPACE_gmfn case, we took a ref of the gfn at the top.
+-     * We also may need to transfer ownership of the page reference to our
+-     * caller.
+-     */
+-    if ( space == XENMAPSPACE_gmfn )
++    switch ( space )
+     {
++    case XENMAPSPACE_gmfn:
++        /*
++         * We took a ref of the gfn at the top.  We also may need to transfer
++         * ownership of the page reference to our caller.
++         */
+         put_gfn(d, gfn);
+         if ( !rc && extra.ppage )
+         {
+             *extra.ppage = page;
+             page = NULL;
+         }
++        break;
++
++    case XENMAPSPACE_grant_table:
++        /*
++         * We (gnttab_map_frame_begin()) acquired a lock and took a ref of the
++         * page underlying the MFN at the top.
++         */
++        gnttab_map_frame_end(d, mfn);
++        break;
+     }
+ 
+     if ( page )
+--- a/xen/common/grant_table.c
++++ b/xen/common/grant_table.c
+@@ -4237,7 +4237,8 @@ int gnttab_acquire_resource(
+     return rc;
+ }
+ 
+-int gnttab_map_frame(struct domain *d, unsigned long idx, gfn_t gfn, mfn_t *mfn)
++int gnttab_map_frame_begin(
++    struct domain *d, unsigned long idx, gfn_t gfn, mfn_t *mfn)
+ {
+     int rc = 0;
+     struct grant_table *gt = d->grant_table;
+@@ -4275,11 +4276,19 @@ int gnttab_map_frame(struct domain *d, u
+             put_page(pg);
+     }
+ 
+-    grant_write_unlock(gt);
++    if ( rc )
++        grant_write_unlock(d->grant_table);
+ 
+     return rc;
+ }
+ 
++void gnttab_map_frame_end(struct domain *d, mfn_t mfn)
++{
++    put_page(mfn_to_page(mfn));
++
++    grant_write_unlock(d->grant_table);
++}
++
+ static void gnttab_usage_print(struct domain *rd)
+ {
+     int first = 1;
+--- a/xen/include/xen/grant_table.h
++++ b/xen/include/xen/grant_table.h
+@@ -53,8 +53,13 @@ int gnttab_release_mappings(struct domai
+ int mem_sharing_gref_to_gfn(struct grant_table *gt, grant_ref_t ref,
+                             gfn_t *gfn, uint16_t *status);
+ 
+-int gnttab_map_frame(struct domain *d, unsigned long idx, gfn_t gfn,
+-                     mfn_t *mfn);
++/*
++ * These need to be used as a pair, as the first (in the success case) returns
++ * with a lock and page reference held which the second needs to drop.
++ */
++int gnttab_map_frame_begin(struct domain *d, unsigned long idx, gfn_t gfn,
++                           mfn_t *mfn);
++void gnttab_map_frame_end(struct domain *d, mfn_t mfn);
+ 
+ unsigned int gnttab_resource_max_frames(const struct domain *d, unsigned int id);
+ 
+@@ -93,12 +98,14 @@ static inline int mem_sharing_gref_to_gf
+     return -EINVAL;
+ }
+ 
+-static inline int gnttab_map_frame(struct domain *d, unsigned long idx,
+-                                   gfn_t gfn, mfn_t *mfn)
++static inline int gnttab_map_frame_begin(struct domain *d, unsigned long idx,
++                                         gfn_t gfn, mfn_t *mfn)
+ {
+     return -EINVAL;
+ }
+ 
++static inline void gnttab_map_frame_end(struct domain *d, mfn_t mfn) {}
++
+ static inline unsigned int gnttab_resource_max_frames(
+     const struct domain *d, unsigned int id)
+ {

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -31,7 +31,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.6
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.6.tar.gz
@@ -297,6 +297,9 @@ Patch253: vtpm-ppi-acpi-dsm.patch
 # XCP-ng patches
 Patch1000: 0001-xenguest-activate-nested-virt-when-requested.patch
 Patch1001: 0002-tools-golang-update-auto-generated-libxl-based-types.patch
+Patch1002: xsa483-4.17.patch
+Patch1003: xsa486-4.18.patch
+Patch1004: x86-amd-Mitigate-AMD-SN-7053-FP-DSS.patch
 
 ExclusiveArch: x86_64
 
@@ -1144,6 +1147,11 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Tue Apr 28 2026 Quentin Casasnovas <quentin.casasnovas@vates.tech> - 4.17.6-6.2
+- Fix for XSA-483 / CVE-2026-23556
+- Fix for XSA-486 / CVE-2026-23558
+- Fix for XSA-488 / CVE-2025-54505
+
 * Wed Mar 25 2026 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.17.6-6.1
 - Sync with XenServer 4.17.6-5
 - Use 0001-xen-mm-don-t-unconditionally-clear-_PGC_need_scrub-i.patch from


### PR DESCRIPTION
Locally built (through mock inside xcp-ng-dev container) RPMs available at: https://nextcloud.vates.tech/index.php/apps/files/files/3595402?dir=/Product%20-%20XCP-ng%20%28private%29/quentin/xen-4.17.6-6.2

# Main information

## Work Item Reference

- XSA-483: https://project.vates.tech/vates-global/browse/XCPNG-3199/
- XSA-486: https://project.vates.tech/vates-global/browse/XCPNG-3194/
- XSA-488: https://project.vates.tech/vates-global/browse/XCPNG-3206/

## Relate changes (optional)

N/A

## Context & Motivation

This update contains three security fixes, two under embargoes (XSA-483, XSA-486) and one already public (XSA-488).

## Release Target

- [x] We already defined a release target with the release team. **The 2026/04/28 12:00UTC**
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

# Release Notes and Documentation

## Explain the change for users

Integration of patches for:

- `XSA-483`: `oxenstored` would not reset the quotas attached to a domain ID on domain tear down. Malicious privileged code in a guest domain could prevent other domains from starting (Denial-of-Service), by exhausting its current quotas and rebooting in a loop, and waiting for its previous domain IDs to be recycled to other domains.
-  `XSA-486`: earlier security fixes for XSA-379 and XSA-387 were incomplete. Incorrect locking still allowed a guest changing from grant table version two to table grant version one to access Xen pages that were de-allocated. Malicious privileged code in a HVM or PVH guest domain could use this use-after-free flaw to potentially escalate its privileges to hypervisor level.
- XSA-488: AMD processors of Zen1 micro-architecture are vulnerable to a side-channel attack leaking floating point registers of certain AVX/SSE instructions. This could allow malicious guests to leak floating point data from other guest domains. There are no other mitigations than rebooting onto a Xen version addressing this vulnerability, which uses a chicken bit in the AMD64_FP_CFG MSR to prevent the micro-architectural leaks as per AMD recommendations.

## Attention points

N/A

## Documentation update needed

- [ ]  Yes
- [x]  No
- [ ] I'm not sure, help me

# Testing and regression avoidance

## What tests have you performed?

Built tested, waiting for CI.

## What manual tests should be performed after the build, and by whom?

None that I'm aware, the patches come from upstream, although a boot test on AMD Zen1 would be nice to have to validate on our hand that XSA-488 fix is sane (it looks fine to me).

## What's covered by the xcp-ng-tests test suite?

Regular regression tests.

## What tests were or will be added to CI for this change? If none, explain why.

None, this update contains **upstream** fixes for security vulnerabilities involving race conditions or otherwise long to trigger issues.  Writing reproducers for these would be too much effort and delay the timely release of the fixes.

# Xen Orchestra Impact

## Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No