### PR TITLE
8.3: Import xen-4.17.6-9.xs8.src.rpm

### DIFF
--- a/SOURCES/backport-3e6bca616b34.patch
+++ b/SOURCES/backport-3e6bca616b34.patch
@@ -1,0 +1,37 @@
+From 3e6bca616b344aaa62602fcef0021255d467c2fd Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Fri, 1 May 2026 20:17:29 +0100
+Subject: x86/svm: Always sync guest CR2 on VMExit
+
+Under SVM, there are two copies of guest CR2.  One is v->arch.hvm.guest_cr[2]
+and one is in the VMCB.
+
+Xen doesn't intercept CR2 accesses, so this mostly goes unnoticed; hardware
+loads and saves the guest CR2 in the VMCB across VMRUN/VMExit.
+
+For HAP guests (where #PF is not intercepted, and therefore we don't typically
+inject #PF either), this causes the guest CR2 value to be lost on migrate.  As
+migration is cooperative and not done from the #PF handler, this also goes
+unnoticed by guests.
+
+It also means that an emulated MOV-from-CR2 reads a stale value.
+
+Reported-by: Stefano Stabellini <sstabellini@kernel.org>
+Fixes: d1bd157fbc9b ("Big merge the HVM full-virtualisation abstractions.")
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Tested-by: Stefano Stabellini <sstabellini@kernel.org>
+Reviewed-by: Teddy Astie <teddy.astie@vates.tech>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+diff --git a/xen/arch/x86/hvm/svm/svm.c b/xen/arch/x86/hvm/svm/svm.c
+index ced616684732..f49d2ebbfdd5 100644
+--- a/xen/arch/x86/hvm/svm/svm.c
++++ b/xen/arch/x86/hvm/svm/svm.c
+@@ -2505,6 +2505,7 @@ void asmlinkage svm_vmexit_handler(void)
+     hvm_sanitize_regs_fields(
+         regs, !(vmcb_get_efer(vmcb) & EFER_LMA) || !(vmcb->cs.l));
+ 
++    v->arch.hvm.guest_cr[2] = vmcb_get_cr2(vmcb);
+     if ( paging_mode_hap(v->domain) )
+         v->arch.hvm.guest_cr[3] = v->arch.hvm.hw_cr[3] = vmcb_get_cr3(vmcb);
+ 

--- a/SOURCES/backport-acfd2631b95e.patch
+++ b/SOURCES/backport-acfd2631b95e.patch
@@ -1,0 +1,66 @@
+From acfd2631b95e29fd68b98d902a1663e07474ed5f Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Fri, 1 May 2026 17:50:44 +0100
+Subject: x86/boot: Disable interrupts when establishing SSP
+
+Gitlab CI reported a crash on boot on Alder Lake hardware.  The bug is years
+old, making it an incredibly rare occurance:
+
+  (XEN) *** DOUBLE FAULT ***
+  (XEN) ----[ Xen-4.22-unstable  x86_64  debug=y ubsan=y  Not tainted ]----
+  (XEN) CPU:    0
+  (XEN) RIP:    e008:[<ffff82d04077bbc4>] arch/x86/setup.c#reinit_bsp_stack+0xfa/0x160
+  (XEN) RFLAGS: 0000000000010202   CONTEXT: hypervisor
+  (XEN) rax: 0000000000000007   rbx: ffff83049a4b0000   rcx: 00000000000006a2
+  (XEN) rdx: 0000000000000000   rsi: 0000000000000000   rdi: 0000000000000000
+  (XEN) rbp: ffff83049a4b7f00   rsp: ffff83049a4b7ef8   r8:  ffff830497e47000
+  (XEN) r9:  00000000ffffffff   r10: 00000000900c2121   r11: 000000009a392956
+  (XEN) r12: ffff830497e47000   r13: ffff830497e49f40   r14: 0000000000000000
+  (XEN) r15: ffff82d0407dad10   cr0: 0000000080050033   cr4: 0000000000f526e0
+  (XEN) cr3: 0000000043c16000   cr2: fffffffffffffffc
+  (XEN) fsb: 0000000000000000   gsb: 0000000000000000   gss: 0000000000000000
+  (XEN) ds: 0000   es: 0000   fs: 0000   gs: 0000   ss: 0000   cs: e008
+  (XEN) Xen code around <ffff82d04077bbc4> (arch/x86/setup.c#reinit_bsp_stack+0xfa/0x160):
+  (XEN)  00 b9 a2 06 00 00 0f 30 <80> 3d 71 26 f1 ff 00 74 3e 48 8d 93 f8 5f 00 00
+  (XEN) Valid stack range: ffff83049a4b6000-ffff83049a4b8000, sp=ffff83049a4b7ef8, tss.rsp0=ffff83049a4b7fb0
+  (XEN) No stack overflow detected. Skipping stack trace.
+  (XEN)
+  (XEN) ****************************************
+  (XEN) Panic on CPU 0:
+  (XEN) DOUBLE FAULT -- system shutdown
+  (XEN) ****************************************
+
+This is on the instruction boundary after enabling CET (writing MSR_S_CET) and
+prior to establishing SSP.  Despite identifying this as a critical window
+where any fault was deadly (the CPU tries to push a shadow stack frame at 0,
+hence the CR2 value wrapping around to the top of the address space), I
+clearly forgot that this meant interrupts too, which are enabled.
+
+Disable interrupts during the critical period.
+
+Fixes: b60ab42db2f0 ("x86/shstk: Activate Supervisor Shadow Stacks")
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Teddy Astie <teddy.astie@vates.tech>
+
+diff --git a/xen/arch/x86/setup.c b/xen/arch/x86/setup.c
+index 425dc1089d4a..5b176e6d5087 100644
+--- a/xen/arch/x86/setup.c
++++ b/xen/arch/x86/setup.c
+@@ -697,8 +697,16 @@ static void __init noreturn reinit_bsp_stack(void)
+     {
+         wrmsrl(MSR_PL0_SSP,
+                (unsigned long)stack + (PRIMARY_SHSTK_SLOT + 1) * PAGE_SIZE - 8);
++
++        /*
++         * Immediately after enabling CET, SSP is 0 and most interrupts and
++         * exceptions are fatal.  Like the SYSCALL/SYSENTER gaps, IST vectors
++         * (including NMI and #MC) are safe owing to IST switching the shstk.
++         */
++        local_irq_disable();
+         wrmsrl(MSR_S_CET, xen_msr_s_cet_value());
+         asm volatile ("setssbsy" ::: "memory");
++        local_irq_enable();
+     }
+ 
+     reset_stack_and_jump(init_done);

--- a/SOURCES/backport-bdb30883f352.patch
+++ b/SOURCES/backport-bdb30883f352.patch
@@ -1,0 +1,87 @@
+From bdb30883f3528676f8b736e4ec0e475914289993 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Tue, 5 May 2026 15:13:28 +0200
+Subject: iommu/amd-vi: do not zero IOMMU MMIO region
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Attempting to memset the whole IOMMU MMIO region to zero is dangerous to
+say the least.  We don't know which registers might be there, nor which
+values might be safe for those registers.  On a forthcoming platform doing
+the zeroing of the MMIO region does put the IOMMU in a broken state, which
+is not recoverable by the IOMMU initialization procedure in Xen.
+
+Instead just zero the control register, which mimics the current behavior
+with regards to how the control register is handled, and ensures the IOMU
+setup is done with the unit disabled.  This approach will need revisiting
+in order to support Preboot DMA Protection.
+
+Fold map_iommu_mmio_region() into its only caller, as the function body is
+just an ioremap() call after the removal of the memset().
+
+Fixes: 0700c962ac2d ("Add AMD IOMMU support into hypervisor")
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Andrew Cooper <andrew.cooper@citrix.com>
+
+diff --git a/xen/drivers/passthrough/amd/iommu_init.c b/xen/drivers/passthrough/amd/iommu_init.c
+index f00e2f49f3ce..2ad6e0462a30 100644
+--- a/xen/drivers/passthrough/amd/iommu_init.c
++++ b/xen/drivers/passthrough/amd/iommu_init.c
+@@ -41,18 +41,6 @@ static bool iommu_has_ht_flag(struct amd_iommu *iommu, u8 mask)
+     return iommu->ht_flags & mask;
+ }
+ 
+-static int __init map_iommu_mmio_region(struct amd_iommu *iommu)
+-{
+-    iommu->mmio_base = ioremap(iommu->mmio_base_phys,
+-                               IOMMU_MMIO_REGION_LENGTH);
+-    if ( !iommu->mmio_base )
+-        return -ENOMEM;
+-
+-    memset(iommu->mmio_base, 0, IOMMU_MMIO_REGION_LENGTH);
+-
+-    return 0;
+-}
+-
+ static void __init unmap_iommu_mmio_region(struct amd_iommu *iommu)
+ {
+     if ( iommu->mmio_base )
+@@ -1360,11 +1348,14 @@ static int __init amd_iommu_prepare_one(struct amd_iommu *iommu)
+ {
+     int rc = alloc_ivrs_mappings(iommu->seg);
+ 
+-    if ( !rc )
+-        rc = map_iommu_mmio_region(iommu);
+     if ( rc )
+         return rc;
+ 
++    iommu->mmio_base = ioremap(iommu->mmio_base_phys,
++                               IOMMU_MMIO_REGION_LENGTH);
++    if ( !iommu->mmio_base )
++        return -ENOMEM;
++
+     get_iommu_features(iommu);
+ 
+     /*
+@@ -1374,6 +1365,20 @@ static int __init amd_iommu_prepare_one(struct amd_iommu *iommu)
+     if ( amd_iommu_max_paging_mode < amd_iommu_min_paging_mode )
+         return -ERANGE;
+ 
++    /*
++     * Check whether the IOMMU is already enabled and unconditionally disable
++     * it (zero the control register) ahead of Xen setup.  Needs to be
++     * revisited to support Preboot DMA Protection.
++     */
++    iommu->ctrl.raw = readq(iommu->mmio_base + IOMMU_CONTROL_MMIO_OFFSET);
++    if ( iommu->ctrl.iommu_en )
++        printk(XENLOG_WARNING
++               "AMD-Vi: IOMMU %pp enabled by firmware (ctrl %016lx)\n",
++               &PCI_SBDF(iommu->seg, iommu->bdf), iommu->ctrl.raw);
++
++    iommu->ctrl.raw = 0;
++    writeq(0, iommu->mmio_base + IOMMU_CONTROL_MMIO_OFFSET);
++
+     return 0;
+ }
+ 

--- a/SOURCES/xsa490-4.17-2.patch
+++ b/SOURCES/xsa490-4.17-2.patch
@@ -1,0 +1,43 @@
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Subject: x86/amd: Mitigate AMD-SN-7052
+
+This is XSA-490 / CVE-2025-54518.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+
+diff --git a/xen/arch/x86/cpu/amd.c b/xen/arch/x86/cpu/amd.c
+index 8c4e50de4536..86268e8619b7 100644
+--- a/xen/arch/x86/cpu/amd.c
++++ b/xen/arch/x86/cpu/amd.c
+@@ -1022,11 +1022,25 @@ static void amd_check_bp_cfg(void)
+ {
+ 	uint64_t val, new = 0;
+ 
+-	/*
+-	 * AMD Erratum #1485.  Set bit 5, as instructed.
+-	 */
+-	if (!cpu_has_hypervisor && boot_cpu_data.x86 == 0x19 && is_zen4_uarch())
+-		new |= (1 << 5);
++	if (!cpu_has_hypervisor) {
++		/*
++		 * AMD Erratum #1485.  If SMT is enabled and STIBP disabled,
++		 * the CPU may fetch incorrect instruction bytes.
++		 *
++		 * Set bit 5, as instructed.
++		 */
++		if (boot_cpu_data.x86 == 0x19 && is_zen4_uarch())
++			new |= (1 << 5);
++
++		/*
++		 * AMD SB-7052.  CPU OP Cache corruption, causing instructions
++		 * to be executed at a higher privilege.
++		 *
++		 * Set bit 33, as instructed.
++		 */
++		if (boot_cpu_data.x86 == 0x17 && is_zen2_uarch())
++			new |= (1UL << 33);
++	}
+ 
+ 	/*
+ 	 * On hardware supporting SRSO_MSR_FIX, activate BP_SPEC_REDUCE by

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -1,6 +1,6 @@
-%global package_speccommit 31454ec14593428f1a66a6c39878fe328b91afd1
+%global package_speccommit 9f872f8199c0212c9ea8bc5dc0331667950e5c9a
 %global usver 4.17.6
-%global xsver 8
+%global xsver 9
 %global xsrel %{xsver}%{?xscount}%{?xshash}
 # -*- rpm-spec -*-
 
@@ -9,7 +9,7 @@
 
 # Hypervisor release.  Should match the tag in the repository and would be in
 # the Release field if it weren't for the %%{xsrel} automagic.
-%global hv_rel 8
+%global hv_rel 9
 
 # Full hash from the HEAD commit of this repo during processing, usually
 # provided by the environment.  Default to ??? if not set.
@@ -233,78 +233,82 @@ Patch190: backport-c4d51191954c.patch
 Patch191: backport-305c6b901a44.patch
 Patch192: backport-986707b461eb.patch
 Patch193: backport-207e11f04f0f.patch
-Patch194: 0006-x86-vpt-fix-injection-to-remote-vCPU.patch
-Patch195: quirk-hp-gen8-rmrr.patch
-Patch196: quirk-pci-phantom-function-devices.patch
-Patch197: 0002-libxc-retry-shadow-ops-if-EBUSY-is-returned.patch
-Patch198: avoid-gnt-unmap-tlb-flush-if-not-accessed.patch
-Patch199: 0001-x86-time-Don-t-use-EFI-s-GetTime-call.patch
-Patch200: 0001-efi-Workaround-page-fault-during-runtime-service.patch
-Patch201: 0001-libxl-Don-t-insert-PCI-device-into-xenstore-for-HVM-.patch
-Patch202: livepatch-ignore-duplicate-new.patch
-Patch203: 0001-lib-Add-a-generic-implementation-of-current_text_add.patch
-Patch204: 0002-sched-Remove-dependency-on-__LINE__-for-release-buil.patch
-Patch205: pygrub-Ignore-GRUB2-if-statements.patch
-Patch206: libfsimage-Add-support-for-btrfs.patch
-Patch207: quiet-broke-irq-affinity.patch
-Patch208: xen-hide-AVX512-on-SKX-by-default.patch
-Patch209: 0001-common-page_alloc-don-t-idle-scrub-before-microcode-.patch
-Patch210: vpci-drop-const.patch
-Patch211: pci-cache-memory-decode-bit.patch
-Patch212: pci-cache-msi-x-enabled-bit.patch
-Patch213: avoid-domctl-lock.patch
-Patch214: tlb-flush-1.patch
-Patch215: tlb-flush-2.patch
-Patch216: xen-tweak-cmdline-defaults.patch
-Patch217: xen-tweak-debug-overhead.patch
-Patch218: tweak-iommu-policy.patch
-Patch219: tweak-sc-policy.patch
-Patch220: disable-core-parking.patch
-Patch221: remove-info-leak.patch
-Patch222: 0001-Allocate-space-in-structs-pre-emptively-to-increase-.patch
-Patch223: 0001-x86-mm-partially-revert-37201c62-make-logdirty-and-i.patch
-Patch224: hitachi-driver-domain-ssid.patch
-Patch225: install_targets_for_test_x86_emulator.patch
-Patch226: xen-define-offsets-for-kdump.patch
-Patch227: xen-scheduler-auto-privdom-weight.patch
-Patch228: xen-hvm-disable-tsc-ramping.patch
-Patch229: xen-default-cpufreq-governor-to-performance-on-intel.patch
-Patch230: i8259-timers-pick-online-vcpu.patch
-Patch231: revert-ca2eee92df44.patch
-Patch232: libxc-cpuid-cores_per_socket.patch
-Patch233: libxc-cpu-clear-deps.patch
-Patch234: libxc-cpu-policies.patch
-Patch235: max-featureset-compat.patch
-Patch236: pygrub-add-disk-as-extra-group.patch
-Patch237: pygrub-add-default-and-extra-args.patch
-Patch238: pygrub-always-boot-default.patch
-Patch239: pygrub-friendly-no-fs.patch
-Patch240: pygrub-default-xenmobile-kernel.patch
-Patch241: pygrub-blacklist-support.patch
-Patch242: oem-bios-xensource.patch
-Patch243: misc-log-guest-consoles.patch
-Patch244: track-nonaffine-time.patch
-Patch245: mixed-domain-runstates.patch
-Patch246: xenguest.patch
-Patch247: xen-vmdebug.patch
-Patch248: 0001-x86-hvmloader-account-for-external-components-consum.patch
-Patch249: oxenstore-censor-sensitive-data.patch
-Patch250: oxenstore-large-packets.patch
-Patch251: nvidia-vga.patch
-Patch252: hvmloader-disable-pci-option-rom-loading.patch
-Patch253: xen-force-software-vmcs-shadow.patch
-Patch254: 0001-x86-vvmx-add-initial-PV-EPT-support-in-L0.patch
-Patch255: use-msr-ll-instead-of-vmcs-efer.patch
-Patch256: revert-4a7e71aa0851-partial.patch
-Patch257: add-pv-iommu-headers.patch
-Patch258: add-pv-iommu-local-domain-ops.patch
-Patch259: add-pv-iommu-foreign-support.patch
-Patch260: upstream-pv-iommu-tools.patch
-Patch261: Add-PV-IOMMU-elf-note.patch
-Patch262: allow-rombios-pci-config-on-any-host-bridge.patch
-Patch263: gvt-g-hvmloader+rombios.patch
-Patch264: xen-spec-ctrl-utility.patch
-Patch265: vtpm-ppi-acpi-dsm.patch
+Patch194: backport-acfd2631b95e.patch
+Patch195: backport-3e6bca616b34.patch
+Patch196: backport-bdb30883f352.patch
+Patch197: xsa490-4.17-2.patch
+Patch198: 0006-x86-vpt-fix-injection-to-remote-vCPU.patch
+Patch199: quirk-hp-gen8-rmrr.patch
+Patch200: quirk-pci-phantom-function-devices.patch
+Patch201: 0002-libxc-retry-shadow-ops-if-EBUSY-is-returned.patch
+Patch202: avoid-gnt-unmap-tlb-flush-if-not-accessed.patch
+Patch203: 0001-x86-time-Don-t-use-EFI-s-GetTime-call.patch
+Patch204: 0001-efi-Workaround-page-fault-during-runtime-service.patch
+Patch205: 0001-libxl-Don-t-insert-PCI-device-into-xenstore-for-HVM-.patch
+Patch206: livepatch-ignore-duplicate-new.patch
+Patch207: 0001-lib-Add-a-generic-implementation-of-current_text_add.patch
+Patch208: 0002-sched-Remove-dependency-on-__LINE__-for-release-buil.patch
+Patch209: pygrub-Ignore-GRUB2-if-statements.patch
+Patch210: libfsimage-Add-support-for-btrfs.patch
+Patch211: quiet-broke-irq-affinity.patch
+Patch212: xen-hide-AVX512-on-SKX-by-default.patch
+Patch213: 0001-common-page_alloc-don-t-idle-scrub-before-microcode-.patch
+Patch214: vpci-drop-const.patch
+Patch215: pci-cache-memory-decode-bit.patch
+Patch216: pci-cache-msi-x-enabled-bit.patch
+Patch217: avoid-domctl-lock.patch
+Patch218: tlb-flush-1.patch
+Patch219: tlb-flush-2.patch
+Patch220: xen-tweak-cmdline-defaults.patch
+Patch221: xen-tweak-debug-overhead.patch
+Patch222: tweak-iommu-policy.patch
+Patch223: tweak-sc-policy.patch
+Patch224: disable-core-parking.patch
+Patch225: remove-info-leak.patch
+Patch226: 0001-Allocate-space-in-structs-pre-emptively-to-increase-.patch
+Patch227: 0001-x86-mm-partially-revert-37201c62-make-logdirty-and-i.patch
+Patch228: hitachi-driver-domain-ssid.patch
+Patch229: install_targets_for_test_x86_emulator.patch
+Patch230: xen-define-offsets-for-kdump.patch
+Patch231: xen-scheduler-auto-privdom-weight.patch
+Patch232: xen-hvm-disable-tsc-ramping.patch
+Patch233: xen-default-cpufreq-governor-to-performance-on-intel.patch
+Patch234: i8259-timers-pick-online-vcpu.patch
+Patch235: revert-ca2eee92df44.patch
+Patch236: libxc-cpuid-cores_per_socket.patch
+Patch237: libxc-cpu-clear-deps.patch
+Patch238: libxc-cpu-policies.patch
+Patch239: max-featureset-compat.patch
+Patch240: pygrub-add-disk-as-extra-group.patch
+Patch241: pygrub-add-default-and-extra-args.patch
+Patch242: pygrub-always-boot-default.patch
+Patch243: pygrub-friendly-no-fs.patch
+Patch244: pygrub-default-xenmobile-kernel.patch
+Patch245: pygrub-blacklist-support.patch
+Patch246: oem-bios-xensource.patch
+Patch247: misc-log-guest-consoles.patch
+Patch248: track-nonaffine-time.patch
+Patch249: mixed-domain-runstates.patch
+Patch250: xenguest.patch
+Patch251: xen-vmdebug.patch
+Patch252: 0001-x86-hvmloader-account-for-external-components-consum.patch
+Patch253: oxenstore-censor-sensitive-data.patch
+Patch254: oxenstore-large-packets.patch
+Patch255: nvidia-vga.patch
+Patch256: hvmloader-disable-pci-option-rom-loading.patch
+Patch257: xen-force-software-vmcs-shadow.patch
+Patch258: 0001-x86-vvmx-add-initial-PV-EPT-support-in-L0.patch
+Patch259: use-msr-ll-instead-of-vmcs-efer.patch
+Patch260: revert-4a7e71aa0851-partial.patch
+Patch261: add-pv-iommu-headers.patch
+Patch262: add-pv-iommu-local-domain-ops.patch
+Patch263: add-pv-iommu-foreign-support.patch
+Patch264: upstream-pv-iommu-tools.patch
+Patch265: Add-PV-IOMMU-elf-note.patch
+Patch266: allow-rombios-pci-config-on-any-host-bridge.patch
+Patch267: gvt-g-hvmloader+rombios.patch
+Patch268: xen-spec-ctrl-utility.patch
+Patch269: vtpm-ppi-acpi-dsm.patch
 
 ExclusiveArch: x86_64
 
@@ -1152,6 +1156,13 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Wed May  6 2026 Andrew Cooper <andrew.cooper3@citrix.com> - 4.17.6-9
+- Fix for XSA-490 CVE-2025-54518
+- Fix crash on boot when setting up shadow stacks
+- Fix hang on boot when configuring the IOMMU on certain AMD platforms
+- Fix a bug on AMD systems where a guests CR2 register value gets lost on
+  migrate
+
 * Wed Apr 22 2026 Andrew Cooper <andrew.cooper3@citrix.com> - 4.17.6-8
 - Fix for XSA-483 CVE-2026-23556
 - Fix for XSA-484 CVE-2026-23557


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3264

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Sync with XenServer release 4.19.6-9

#### Release Target

- [X] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

ASAP. Will publish on forum for user testing, do the CI, and officially update on Monday.

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

This update contains fix for CVE-2025-54518 concerning some AMD CPUs. It also contains fixes for possible crashes at boot time and a bug, still on AMD system, regarding CR2 register value being lost while migrating guests.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

<!-- Add links to the documentation update PRs if/when they are created. -->

PR links: N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Build and install locally and ran pytest vm-basic-operations.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

N/A

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Usual CI tests

#### What tests have been or will be added to CI for this change? If none, explain why.

None, already covered by existing tests

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
