### PR TITLE
common: exclude pv_iommu from non-x86 builds

### DIFF
--- a/SOURCES/common-exclude-pv_iommu-from-non-x86-builds.patch
+++ b/SOURCES/common-exclude-pv_iommu-from-non-x86-builds.patch
@@ -1,0 +1,30 @@
+From f578a20b4a3a41bce02fc84d4358d4bffee423f7 Mon Sep 17 00:00:00 2001
+From: Julian Vetter <julian.vetter@vates.tech>
+Date: Mon, 8 Jun 2026 13:31:37 +0200
+Subject: [PATCH] common: exclude pv_iommu from non-x86 builds
+
+The PV IOMMU code uses x86-specific APIs (p2m, paging_mode_translate,
+boot_cpu_data) and has no relevance on ARM, which has no PV guest
+support. So, make the pv_iommu.o dependant on CONFIG_X86.
+
+Signed-off-by: Julian Vetter <julian.vetter@vates.tech>
+---
+ xen/common/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xen/common/Makefile b/xen/common/Makefile
+index e24369ee9a..9c3aee1e6d 100644
+--- a/xen/common/Makefile
++++ b/xen/common/Makefile
+@@ -39,7 +39,7 @@ obj-y += percpu.o
+ obj-$(CONFIG_PERF_COUNTERS) += perfc.o
+ obj-bin-$(CONFIG_HAS_PMAP) += pmap.init.o
+ obj-y += preempt.o
+-obj-y += pv_iommu.o
++obj-$(CONFIG_X86) += pv_iommu.o
+ obj-y += random.o
+ obj-y += rangeset.o
+ obj-y += radix-tree.o
+-- 
+2.53.0
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -226,6 +226,7 @@ Patch181: elf-note-filtering.patch
 %if 0%{?xcpng}
 Patch1000: xcpng-no-default-lockdown.patch
 %endif
+Patch1001: common-exclude-pv_iommu-from-non-x86-builds.patch
 
 ExclusiveArch: %{x86_64}
 


### PR DESCRIPTION
pv_iommu is an out-of-tree XCP-ng patch with no upstream equivalent. It uses x86-specific APIs (p2m, paging_mode_translate, boot_cpu_data) and has no relevance on ARM, which has no PV guest support anyway. So, make the pv_iommu.c build dependant on x86.

### Main information

#### Work Item Reference

XCPNG-3362

#### Related changes (optional)

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

In the future we want to have a single Xen RPM source repo that allows to build x86 and ARM targets. So, fix patches that prevent an ARM target to compile. 

#### Release Target

- [ ] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [x] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->


---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

In the future we want to have a single Xen RPM source repo that allows to build x86 and ARM targets. So, fix patches that prevent an ARM target to compile. 

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->


<!-- Add links to the documentation update PRs if/when they are created. -->



---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Tested that the compilation error in regards to this file go away when building for ARM.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

None, for now.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

None

#### What tests have been or will be added to CI for this change? If none, explain why.

None. This only concerns ARM targets, which don't exist yet.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
