### PR TITLE
Set team owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @xcp-ng-rpms/hypervisor-kernel @xcp-ng-rpms/os-platform-release


### PR DESCRIPTION
Code owner configuration was lost when reverting during the `master` branch cleanup