### PR TITLE
Import upstream patch to drop ThumbEE support

### DIFF
--- a/SOURCES/arm-drop-thumbee-support.patch
+++ b/SOURCES/arm-drop-thumbee-support.patch
@@ -1,0 +1,106 @@
+From 5bbe1fe413f9d6a841b0bc70db024b1398391630 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Wed, 3 Dec 2025 17:00:04 +0000
+Subject: [PATCH] ARM: Drop ThumbEE support
+
+Hans reports that Xen no longer builds on Debian unstable/sid:
+
+  Assembler messages:
+  {standard input}:474: Error: unknown or missing system register name at operand 1 -- `msr TEECR32_EL1,x0'
+  {standard input}:480: Error: unknown or missing system register name at operand 1 -- `msr TEEHBR32_EL1,x0'
+  {standard input}:488: Error: unknown or missing system register name at operand 2 -- `mrs x0,TEECR32_EL1'
+  {standard input}:494: Error: unknown or missing system register name at operand 2 -- `mrs x0,TEEHBR32_EL1'
+  make[5]: *** [Rules.mk:249: arch/arm/domain.o] Error 1
+
+This turns out to be an intentional change in binutils.  ThumbEE was dropped
+ahead of ARM v8 (i.e. AArch64).
+
+Xen supports ARM v7+virt extensions so in principle we could #ifdef
+CONFIG_ARM_32 to keep it working.  However, there was apparently no use of
+ThumbEE outside of demo code, so simply drop it.
+
+On ThumbEE capable hardware, unconditionally trap ThumbEE instructions, and
+drop the context switching logic for TEE{CR,HBR}32.
+
+Reported-by: Hans van Kranenburg <hans@knorrie.org>
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Bertrand Marquis <bertrand.marquis@arm.com>
+---
+ xen/arch/arm/domain.c                | 12 ------------
+ xen/arch/arm/include/asm/domain.h    |  1 -
+ xen/arch/arm/include/asm/processor.h |  1 +
+ xen/arch/arm/traps.c                 |  4 ++--
+ 4 files changed, 3 insertions(+), 15 deletions(-)
+
+diff --git a/xen/arch/arm/domain.c b/xen/arch/arm/domain.c
+index ab78444335..3e32a15cac 100644
+--- a/xen/arch/arm/domain.c
++++ b/xen/arch/arm/domain.c
+@@ -111,12 +111,6 @@ static void ctxt_switch_from(struct vcpu *p)
+     p->arch.cntkctl = READ_SYSREG(CNTKCTL_EL1);
+     virt_timer_save(p);
+ 
+-    if ( is_32bit_domain(p->domain) && cpu_has_thumbee )
+-    {
+-        p->arch.teecr = READ_SYSREG(TEECR32_EL1);
+-        p->arch.teehbr = READ_SYSREG(TEEHBR32_EL1);
+-    }
+-
+ #ifdef CONFIG_ARM_32
+     p->arch.joscr = READ_CP32(JOSCR);
+     p->arch.jmcr = READ_CP32(JMCR);
+@@ -244,12 +238,6 @@ static void ctxt_switch_to(struct vcpu *n)
+     WRITE_SYSREG(n->arch.tpidrro_el0, TPIDRRO_EL0);
+     WRITE_SYSREG(n->arch.tpidr_el1, TPIDR_EL1);
+ 
+-    if ( is_32bit_domain(n->domain) && cpu_has_thumbee )
+-    {
+-        WRITE_SYSREG(n->arch.teecr, TEECR32_EL1);
+-        WRITE_SYSREG(n->arch.teehbr, TEEHBR32_EL1);
+-    }
+-
+ #ifdef CONFIG_ARM_32
+     WRITE_CP32(n->arch.joscr, JOSCR);
+     WRITE_CP32(n->arch.jmcr, JMCR);
+diff --git a/xen/arch/arm/include/asm/domain.h b/xen/arch/arm/include/asm/domain.h
+index af3e168374..758ad807e4 100644
+--- a/xen/arch/arm/include/asm/domain.h
++++ b/xen/arch/arm/include/asm/domain.h
+@@ -211,7 +211,6 @@ struct arch_vcpu
+     register_t hcr_el2;
+     register_t mdcr_el2;
+ 
+-    uint32_t teecr, teehbr; /* ThumbEE, 32-bit guests only */
+ #ifdef CONFIG_ARM_32
+     /*
+      * ARMv8 only supports a trivial implementation on Jazelle when in AArch32
+diff --git a/xen/arch/arm/include/asm/processor.h b/xen/arch/arm/include/asm/processor.h
+index ed56746368..1a48c9ff3b 100644
+--- a/xen/arch/arm/include/asm/processor.h
++++ b/xen/arch/arm/include/asm/processor.h
+@@ -411,6 +411,7 @@
+ 
+ /* HSTR Hyp. System Trap Register */
+ #define HSTR_T(x)       ((_AC(1,U)<<(x)))       /* Trap Cp15 c<x> */
++#define HSTR_TTEE       (_AC(1,U)<<16)          /* Trap ThumbEE */
+ 
+ /* HDCR Hyp. Debug Configuration Register */
+ #define HDCR_TDRA       (_AC(1,U)<<11)          /* Trap Debug ROM access */
+diff --git a/xen/arch/arm/traps.c b/xen/arch/arm/traps.c
+index 2bc3e1df04..040c0f2e0d 100644
+--- a/xen/arch/arm/traps.c
++++ b/xen/arch/arm/traps.c
+@@ -141,8 +141,8 @@ void init_traps(void)
+     WRITE_SYSREG(HDCR_TDRA|HDCR_TDOSA|HDCR_TDA|HDCR_TPM|HDCR_TPMCR,
+                  MDCR_EL2);
+ 
+-    /* Trap CP15 c15 used for implementation defined registers */
+-    WRITE_SYSREG(HSTR_T(15), HSTR_EL2);
++    /* Trap CP15 c15 used for implementation defined registers, and ThumbEE. */
++    WRITE_SYSREG(HSTR_T(15) | (cpu_has_thumbee ? HSTR_TTEE : 0), HSTR_EL2);
+ 
+     /* Trap all coprocessor registers (0-13) except cp10 and
+      * cp11 for VFP.
+-- 
+2.53.0
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -226,6 +226,7 @@ Patch181: elf-note-filtering.patch
 %if 0%{?xcpng}
 Patch1000: xcpng-no-default-lockdown.patch
 %endif
+Patch1001: arm-drop-thumbee-support.patch
 
 ExclusiveArch: %{x86_64}
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3362

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Same as pull request https://github.com/xcp-ng-rpms/xen/pull/91. In the future we want to have a single Xen RPM source repo that allows to build x86 and ARM targets. So, add patches that prevent an ARM target to compile.

#### Release Target

- [ ] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [x] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->


---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

No changes. This is purely a preparatory change. In the future when we have ARM support, this patch needs to be picked up to not break compilation on newer machines.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

EXPLANATIONS

<!-- Add links to the documentation update PRs if/when they are created. -->

N/A

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Tested that the compilation error in regards to this file go away when building for ARM.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

None

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

None.

#### What tests have been or will be added to CI for this change? If none, explain why.

None. This only concerns ARM targets, which don't exist yet.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
