### PR TITLE
Backport patches for XSA-491, XSA-492, and XSA-494

### DIFF
--- a/SOURCES/0001-x86-HVM-add-locking-to-I-O-port-translation-list-tra.patch
+++ b/SOURCES/0001-x86-HVM-add-locking-to-I-O-port-translation-list-tra.patch
@@ -1,0 +1,241 @@
+From 045b5e7bba4c1a69b584188f9cf13b398967977c Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Mon, 1 Jun 2026 16:01:37 +0200
+Subject: [PATCH] x86/HVM: add locking to I/O port translation list traversal
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+XEN_DOMCTL_ioport_mapping is usable by DM stubdoms, and hence we can't
+assume the list to be left unaltered while the guest (really: the
+hypervisor on behalf of the guest) is accessing it.
+
+This is XSA-491 / CVE-2026-42487.
+
+Fixes: 192c4dabc344 ("domctl and p2m changes for PCI passthru")
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+---
+ xen/arch/x86/domctl.c                 |  8 +++
+ xen/arch/x86/hvm/emulate.c            |  1 -
+ xen/arch/x86/hvm/hvm.c                |  1 +
+ xen/arch/x86/hvm/io.c                 | 72 +++++++++++++++++++--------
+ xen/arch/x86/include/asm/hvm/domain.h |  1 +
+ xen/arch/x86/include/asm/hvm/vcpu.h   |  2 -
+ 6 files changed, 61 insertions(+), 24 deletions(-)
+
+diff --git a/xen/arch/x86/domctl.c b/xen/arch/x86/domctl.c
+index 0af1812124..67dc26dce7 100644
+--- a/xen/arch/x86/domctl.c
++++ b/xen/arch/x86/domctl.c
+@@ -643,6 +643,7 @@ long arch_do_domctl(
+                    "ioport_map:add: dom%d gport=%x mport=%x nr=%x\n",
+                    d->domain_id, fgp, fmp, np);
+ 
++            write_lock(&hvm->g2m_ioport_lock);
+             list_for_each_entry(g2m_ioport, &hvm->g2m_ioport_list, list)
+                 if (g2m_ioport->mport == fmp )
+                 {
+@@ -664,11 +665,14 @@ long arch_do_domctl(
+                 g2m_ioport->np = np;
+                 list_add_tail(&g2m_ioport->list, &hvm->g2m_ioport_list);
+             }
++            write_unlock(&hvm->g2m_ioport_lock);
+             if ( !ret )
+                 ret = ioports_permit_access(d, fmp, fmp + np - 1);
+             if ( ret && !found && g2m_ioport )
+             {
++                write_lock(&hvm->g2m_ioport_lock);
+                 list_del(&g2m_ioport->list);
++                write_unlock(&hvm->g2m_ioport_lock);
+                 xfree(g2m_ioport);
+             }
+         }
+@@ -677,6 +681,8 @@ long arch_do_domctl(
+             printk(XENLOG_G_INFO
+                    "ioport_map:remove: dom%d gport=%x mport=%x nr=%x\n",
+                    d->domain_id, fgp, fmp, np);
++
++            write_lock(&hvm->g2m_ioport_lock);
+             list_for_each_entry(g2m_ioport, &hvm->g2m_ioport_list, list)
+                 if ( g2m_ioport->mport == fmp )
+                 {
+@@ -684,6 +690,8 @@ long arch_do_domctl(
+                     xfree(g2m_ioport);
+                     break;
+                 }
++            write_unlock(&hvm->g2m_ioport_lock);
++
+             ret = ioports_deny_access(d, fmp, fmp + np - 1);
+             if ( ret && is_hardware_domain(currd) )
+                 printk(XENLOG_ERR
+diff --git a/xen/arch/x86/hvm/emulate.c b/xen/arch/x86/hvm/emulate.c
+index 27928dc3f3..464c43d035 100644
+--- a/xen/arch/x86/hvm/emulate.c
++++ b/xen/arch/x86/hvm/emulate.c
+@@ -145,7 +145,6 @@ void hvmemul_cancel(struct vcpu *v)
+     hvio->mmio_insn_bytes = 0;
+     hvio->mmio_access = (struct npfec){};
+     hvio->mmio_retry = false;
+-    hvio->g2m_ioport = NULL;
+ 
+     hvmemul_cache_disable(v);
+ }
+diff --git a/xen/arch/x86/hvm/hvm.c b/xen/arch/x86/hvm/hvm.c
+index 8dd0dc4013..96a18e525e 100644
+--- a/xen/arch/x86/hvm/hvm.c
++++ b/xen/arch/x86/hvm/hvm.c
+@@ -588,6 +588,7 @@ int hvm_domain_initialise(struct domain *d,
+     spin_lock_init(&d->arch.hvm.irq_lock);
+     spin_lock_init(&d->arch.hvm.uc_lock);
+     spin_lock_init(&d->arch.hvm.write_map.lock);
++    rwlock_init(&d->arch.hvm.g2m_ioport_lock);
+     rwlock_init(&d->arch.hvm.mmcfg_lock);
+     INIT_LIST_HEAD(&d->arch.hvm.write_map.list);
+     INIT_LIST_HEAD(&d->arch.hvm.g2m_ioport_list);
+diff --git a/xen/arch/x86/hvm/io.c b/xen/arch/x86/hvm/io.c
+index 5b880a0584..890140e3c6 100644
+--- a/xen/arch/x86/hvm/io.c
++++ b/xen/arch/x86/hvm/io.c
+@@ -157,36 +157,56 @@ bool handle_pio(uint16_t port, unsigned int size, int dir)
+     return true;
+ }
+ 
+-static bool cf_check g2m_portio_accept(
+-    const struct hvm_io_handler *handler, const ioreq_t *p)
++/* NB: Returns with the lock held in the success case. */
++static const struct g2m_ioport *g2m_portio_find_and_lock(struct hvm_domain *hvm,
++                                                         uint64_t addr,
++                                                         uint32_t size)
+ {
+-    struct vcpu *curr = current;
+-    const struct hvm_domain *hvm = &curr->domain->arch.hvm;
+-    struct hvm_vcpu_io *hvio = &curr->arch.hvm.hvm_io;
+-    struct g2m_ioport *g2m_ioport;
+-    unsigned int start, end;
++    const struct g2m_ioport *g2m_ioport;
++
++    read_lock(&hvm->g2m_ioport_lock);
+ 
+     list_for_each_entry( g2m_ioport, &hvm->g2m_ioport_list, list )
+     {
+-        start = g2m_ioport->gport;
+-        end = start + g2m_ioport->np;
+-        if ( (p->addr >= start) && (p->addr + p->size <= end) )
+-        {
+-            hvio->g2m_ioport = g2m_ioport;
+-            return 1;
+-        }
++        unsigned int start = g2m_ioport->gport;
++
++        if ( addr >= start && addr + size <= start + g2m_ioport->np )
++            return g2m_ioport;
+     }
+ 
+-    return 0;
++    read_unlock(&hvm->g2m_ioport_lock);
++
++    return NULL;
++}
++
++static bool cf_check g2m_portio_accept(
++    const struct hvm_io_handler *handler, const ioreq_t *p)
++{
++    struct hvm_domain *hvm = &current->domain->arch.hvm;
++    const struct g2m_ioport *g2m_ioport =
++        g2m_portio_find_and_lock(hvm, p->addr, p->size);
++
++    if ( !g2m_ioport )
++        return false;
++
++    read_unlock(&hvm->g2m_ioport_lock);
++
++    return true;
+ }
+ 
+ static int cf_check g2m_portio_read(
+     const struct hvm_io_handler *handler, uint64_t addr, uint32_t size,
+     uint64_t *data)
+ {
+-    struct hvm_vcpu_io *hvio = &current->arch.hvm.hvm_io;
+-    const struct g2m_ioport *g2m_ioport = hvio->g2m_ioport;
+-    unsigned int mport = (addr - g2m_ioport->gport) + g2m_ioport->mport;
++    struct hvm_domain *hvm = &current->domain->arch.hvm;
++    const struct g2m_ioport *g2m_ioport =
++        g2m_portio_find_and_lock(hvm, addr, size);
++    unsigned int mport;
++
++    if ( !g2m_ioport )
++        return X86EMUL_RETRY;
++
++    mport = addr - g2m_ioport->gport + g2m_ioport->mport;
+ 
+     switch ( size )
+     {
+@@ -203,6 +223,8 @@ static int cf_check g2m_portio_read(
+         BUG();
+     }
+ 
++    read_unlock(&hvm->g2m_ioport_lock);
++
+     return X86EMUL_OKAY;
+ }
+ 
+@@ -210,9 +232,15 @@ static int cf_check g2m_portio_write(
+     const struct hvm_io_handler *handler, uint64_t addr, uint32_t size,
+     uint64_t data)
+ {
+-    struct hvm_vcpu_io *hvio = &current->arch.hvm.hvm_io;
+-    const struct g2m_ioport *g2m_ioport = hvio->g2m_ioport;
+-    unsigned int mport = (addr - g2m_ioport->gport) + g2m_ioport->mport;
++    struct hvm_domain *hvm = &current->domain->arch.hvm;
++    const struct g2m_ioport *g2m_ioport =
++        g2m_portio_find_and_lock(hvm, addr, size);
++    unsigned int mport;
++
++    if ( !g2m_ioport )
++        return X86EMUL_RETRY;
++
++    mport = addr - g2m_ioport->gport + g2m_ioport->mport;
+ 
+     switch ( size )
+     {
+@@ -229,6 +257,8 @@ static int cf_check g2m_portio_write(
+         BUG();
+     }
+ 
++    read_unlock(&hvm->g2m_ioport_lock);
++
+     return X86EMUL_OKAY;
+ }
+ 
+diff --git a/xen/arch/x86/include/asm/hvm/domain.h b/xen/arch/x86/include/asm/hvm/domain.h
+index 0b86329ea3..c45fa0ff2b 100644
+--- a/xen/arch/x86/include/asm/hvm/domain.h
++++ b/xen/arch/x86/include/asm/hvm/domain.h
+@@ -136,6 +136,7 @@ struct hvm_domain {
+ 
+     /* List of guest to machine IO ports mapping. */
+     struct list_head g2m_ioport_list;
++    rwlock_t g2m_ioport_lock;
+ 
+     /* List of MMCFG regions trapped by Xen. */
+     struct list_head mmcfg_regions;
+diff --git a/xen/arch/x86/include/asm/hvm/vcpu.h b/xen/arch/x86/include/asm/hvm/vcpu.h
+index 8adf4555c2..b4044d6a57 100644
+--- a/xen/arch/x86/include/asm/hvm/vcpu.h
++++ b/xen/arch/x86/include/asm/hvm/vcpu.h
+@@ -76,8 +76,6 @@ struct hvm_vcpu_io {
+     unsigned long msix_unmask_address;
+     unsigned long msix_snoop_address;
+     unsigned long msix_snoop_gpa;
+-
+-    const struct g2m_ioport *g2m_ioport;
+ };
+ 
+ struct nestedvcpu {
+-- 
+2.53.0
+

--- a/SOURCES/0001-x86-mm-accurately-track-which-vCPU-page-tables-are-l.patch
+++ b/SOURCES/0001-x86-mm-accurately-track-which-vCPU-page-tables-are-l.patch
@@ -1,0 +1,406 @@
+From 431250797b7b788599adcdf936a56b4a10e4b52f Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Fri, 5 Jun 2026 16:01:25 +0200
+Subject: [PATCH] x86/mm: accurately track which vCPU page-tables are loaded
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Neither current nor curr_vcpu per-CPU fields accurately track which
+page-tables are loaded.  There are corner cases when dealing with shadow
+paging failures that switch to the idle vCPU page-tables without changing
+current or curr_vcpu per-CPU fields.
+
+Introduce a new per-CPU field that attempts to track which vCPU page-tables
+are loaded.  Update such tracking when cr3 is changed, and do so in a
+region with interrupts disabled, as to avoid handling interrupts with a
+mismatch between the vCPU tracking field and the loaded page-tables.
+
+As a result of this newly more accurate tracking the mapcache override
+functionality can be removed: the dom0 PV builder was the only user of it,
+and it's updated here to properly signal which vCPU page-tables are loaded
+in the calls to switch_cr3_cr4().
+
+Note the EFI page-tables have the Xen owned L4 slots copied from the idle
+page-tables, so for the effects of the mapcache the EFI page-tables could
+use the idle mapcache if it had one.  Pass the idle vCPU in the
+switch_cr3_cr4() call that switches to the runtime EFI page-tables.
+
+There are known issues with the use of mapcache in NMI context.  This patch
+does not alter the behaviour.
+
+This is CVE-2026-42488 / XSA-494.
+
+Fixes: fb0ff49fe9f7 ("x86/shadow: defer releasing of PV's top-level shadow reference")
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Acked-by: Andrew Cooper <andrew.cooper3@citrix.com>
+---
+ xen/arch/x86/domain_page.c           | 48 ++++++++++++----------------
+ xen/arch/x86/flushtlb.c              |  5 ++-
+ xen/arch/x86/include/asm/domain.h    |  1 -
+ xen/arch/x86/include/asm/flushtlb.h  |  2 +-
+ xen/arch/x86/include/asm/processor.h |  3 ++
+ xen/arch/x86/mm.c                    |  4 +--
+ xen/arch/x86/pv/dom0_build.c         | 12 +++----
+ xen/arch/x86/pv/domain.c             | 13 ++++++--
+ xen/arch/x86/smpboot.c               |  1 +
+ xen/common/efi/common-stub.c         |  5 ---
+ xen/common/efi/runtime.c             | 21 +++++-------
+ xen/include/xen/efi.h                |  1 -
+ 12 files changed, 54 insertions(+), 62 deletions(-)
+
+diff --git a/xen/arch/x86/domain_page.c b/xen/arch/x86/domain_page.c
+index eac5e3304f..72c00194f3 100644
+--- a/xen/arch/x86/domain_page.c
++++ b/xen/arch/x86/domain_page.c
+@@ -18,48 +18,40 @@
+ #include <asm/hardirq.h>
+ #include <asm/setup.h>
+ 
+-static DEFINE_PER_CPU(struct vcpu *, override);
+-
+ static inline struct vcpu *mapcache_current_vcpu(void)
+ {
+-    /* In the common case we use the mapcache of the running VCPU. */
+-    struct vcpu *v = this_cpu(override) ?: current;
+-
+-    /*
+-     * When current isn't properly set up yet, this is equivalent to
+-     * running in an idle vCPU (callers must check for NULL).
+-     */
+-    if ( !v )
+-        return NULL;
++    struct vcpu *v = this_cpu(pgtable_vcpu);
++    struct vcpu *curr = current;
+ 
+     /*
+-     * When using efi runtime page tables, we have the equivalent of the idle
+-     * domain's page tables but current may point at another domain's VCPU.
+-     * Return NULL as though current is not properly set up yet.
++     * During early boot pgtable_vcpu is not set, callers must handle NULL.
++     * Non-PV domains don't have a mapcache, the directmap covers all physical
++     * address space.
+      */
+-    if ( efi_rs_using_pgtables() )
++    if ( !v || !is_pv_vcpu(v) )
+         return NULL;
+ 
+     /*
+-     * If guest_table is NULL, and we are running a paravirtualised guest,
+-     * then it means we are running on the idle domain's page table and must
+-     * therefore use its mapcache.
++     * If we are in a lazy context-switch state from a PV vCPU do a full switch
++     * to the idle vCPU now, otherwise an incoming FLUSH_VCPU_STATE IPI would
++     * change the page tables under our feet an invalidate any in-use mapcache
++     * entries.
+      */
+-    if ( unlikely(pagetable_is_null(v->arch.guest_table)) && is_pv_vcpu(v) )
++    if ( unlikely(this_cpu(curr_vcpu) != curr) )
+     {
+-        /* If we really are idling, perform lazy context switch now. */
+-        if ( (v = idle_vcpu[smp_processor_id()]) == current )
+-            sync_local_execstate();
++        ASSERT(curr == idle_vcpu[smp_processor_id()]);
++        sync_local_execstate();
+         /* We must now be running on the idle page table. */
+         ASSERT(cr3_pa(read_cr3()) == __pa(idle_pg_table));
+     }
+ 
+-    return v;
+-}
+-
+-void __init mapcache_override_current(struct vcpu *v)
+-{
+-    this_cpu(override) = v;
++    /*
++     * At this point we can guarantee Xen is not in lazy context switch: either
++     * the code above will have synced the state, or an incoming
++     * FLUSH_VCPU_STATE IPI has done so behind our back.  Use ACCESS_ONCE to
++     * ensure the compiler never returns the locally cached pgtable_vcpu value.
++     */
++    return ACCESS_ONCE(this_cpu(pgtable_vcpu));
+ }
+ 
+ #define mapcache_l2_entry(e) ((e) >> PAGETABLE_ORDER)
+diff --git a/xen/arch/x86/flushtlb.c b/xen/arch/x86/flushtlb.c
+index 416ae5531d..8dc22cc5c8 100644
+--- a/xen/arch/x86/flushtlb.c
++++ b/xen/arch/x86/flushtlb.c
+@@ -106,7 +106,9 @@ static void do_tlb_flush(void)
+     local_irq_restore(flags);
+ }
+ 
+-void switch_cr3_cr4(unsigned long cr3, unsigned long cr4)
++DEFINE_PER_CPU(struct vcpu *, pgtable_vcpu);
++
++void switch_cr3_cr4(struct vcpu *v, unsigned long cr3, unsigned long cr4)
+ {
+     unsigned long flags, old_cr4;
+     u32 t = 0;
+@@ -150,6 +152,7 @@ void switch_cr3_cr4(unsigned long cr3, unsigned long cr4)
+     if ( (old_cr4 & X86_CR4_PCIDE) > (cr4 & X86_CR4_PCIDE) )
+         cr3 |= X86_CR3_NOFLUSH;
+     write_cr3(cr3);
++    this_cpu(pgtable_vcpu) = v;
+ 
+     if ( old_cr4 != cr4 )
+         write_cr4(cr4);
+diff --git a/xen/arch/x86/include/asm/domain.h b/xen/arch/x86/include/asm/domain.h
+index f90a268b01..588b56b3fd 100644
+--- a/xen/arch/x86/include/asm/domain.h
++++ b/xen/arch/x86/include/asm/domain.h
+@@ -76,7 +76,6 @@ struct mapcache_domain {
+ 
+ int mapcache_domain_init(struct domain *);
+ int mapcache_vcpu_init(struct vcpu *);
+-void mapcache_override_current(struct vcpu *);
+ 
+ /* x86/64: toggle guest between kernel and user modes. */
+ void toggle_guest_mode(struct vcpu *);
+diff --git a/xen/arch/x86/include/asm/flushtlb.h b/xen/arch/x86/include/asm/flushtlb.h
+index a461ee36ff..821ffe3e8b 100644
+--- a/xen/arch/x86/include/asm/flushtlb.h
++++ b/xen/arch/x86/include/asm/flushtlb.h
+@@ -99,7 +99,7 @@ static inline unsigned long read_cr3(void)
+ }
+ 
+ /* Write pagetable base and implicitly tick the tlbflush clock. */
+-void switch_cr3_cr4(unsigned long cr3, unsigned long cr4);
++void switch_cr3_cr4(struct vcpu *v, unsigned long cr3, unsigned long cr4);
+ 
+ /* flush_* flag fields: */
+  /*
+diff --git a/xen/arch/x86/include/asm/processor.h b/xen/arch/x86/include/asm/processor.h
+index e516c3b24a..f81c2ea813 100644
+--- a/xen/arch/x86/include/asm/processor.h
++++ b/xen/arch/x86/include/asm/processor.h
+@@ -427,6 +427,9 @@ extern idt_entry_t *idt_tables[];
+ 
+ DECLARE_PER_CPU(root_pgentry_t *, root_pgt);
+ 
++/* vCPU of the currently loaded page-tables. */
++DECLARE_PER_CPU(struct vcpu *, pgtable_vcpu);
++
+ extern void write_ptbase(struct vcpu *v);
+ 
+ /* REP NOP (PAUSE) is a good thing to insert into busy-wait loops. */
+diff --git a/xen/arch/x86/mm.c b/xen/arch/x86/mm.c
+index 076a7e2295..8f4fa1e9b7 100644
+--- a/xen/arch/x86/mm.c
++++ b/xen/arch/x86/mm.c
+@@ -546,7 +546,7 @@ void write_ptbase(struct vcpu *v)
+         cpu_info->pv_cr3 = __pa(this_cpu(root_pgt));
+         if ( new_cr4 & X86_CR4_PCIDE )
+             cpu_info->pv_cr3 |= get_pcid_bits(v, true);
+-        switch_cr3_cr4(v->arch.cr3, new_cr4);
++        switch_cr3_cr4(v, v->arch.cr3, new_cr4);
+     }
+     else
+     {
+@@ -554,7 +554,7 @@ void write_ptbase(struct vcpu *v)
+         cpu_info->use_pv_cr3 = false;
+         cpu_info->xen_cr3 = 0;
+         /* switch_cr3_cr4() serializes. */
+-        switch_cr3_cr4(v->arch.cr3, new_cr4);
++        switch_cr3_cr4(v, v->arch.cr3, new_cr4);
+         cpu_info->pv_cr3 = 0;
+     }
+ }
+diff --git a/xen/arch/x86/pv/dom0_build.c b/xen/arch/x86/pv/dom0_build.c
+index 7f009fee92..afa7e717aa 100644
+--- a/xen/arch/x86/pv/dom0_build.c
++++ b/xen/arch/x86/pv/dom0_build.c
+@@ -811,8 +811,7 @@ int __init dom0_construct_pv(struct domain *d,
+         update_cr3(v);
+ 
+     /* We run on dom0's page tables for the final part of the build process. */
+-    switch_cr3_cr4(cr3_pa(v->arch.cr3), read_cr4());
+-    mapcache_override_current(v);
++    switch_cr3_cr4(v, cr3_pa(v->arch.cr3), read_cr4());
+ 
+     /* Copy the OS image and free temporary buffer. */
+     elf.dest_base = (void*)vkern_start;
+@@ -821,8 +820,7 @@ int __init dom0_construct_pv(struct domain *d,
+     rc = elf_load_binary(&elf);
+     if ( rc < 0 )
+     {
+-        mapcache_override_current(NULL);
+-        switch_cr3_cr4(current->arch.cr3, read_cr4());
++        switch_cr3_cr4(current, current->arch.cr3, read_cr4());
+         printk("Failed to load the kernel binary\n");
+         goto out;
+     }
+@@ -833,8 +831,7 @@ int __init dom0_construct_pv(struct domain *d,
+         if ( (parms.virt_hypercall < v_start) ||
+              (parms.virt_hypercall >= v_end) )
+         {
+-            mapcache_override_current(NULL);
+-            switch_cr3_cr4(current->arch.cr3, read_cr4());
++            switch_cr3_cr4(current, current->arch.cr3, read_cr4());
+             printk("Invalid HYPERCALL_PAGE field in ELF notes.\n");
+             return -EINVAL;
+         }
+@@ -975,8 +972,7 @@ int __init dom0_construct_pv(struct domain *d,
+ #endif
+ 
+     /* Return to idle domain's page tables. */
+-    mapcache_override_current(NULL);
+-    switch_cr3_cr4(current->arch.cr3, read_cr4());
++    switch_cr3_cr4(current, current->arch.cr3, read_cr4());
+ 
+     update_domain_wallclock_time(d);
+ 
+diff --git a/xen/arch/x86/pv/domain.c b/xen/arch/x86/pv/domain.c
+index 5302f7b366..6d037075d6 100644
+--- a/xen/arch/x86/pv/domain.c
++++ b/xen/arch/x86/pv/domain.c
+@@ -456,6 +456,8 @@ static void _toggle_guest_pt(struct vcpu *v)
+     pagetable_t old_shadow;
+     unsigned long cr3;
+ 
++    ASSERT(local_irq_is_enabled());
++
+     v->arch.flags ^= TF_kernel_mode;
+     guest_update = v->arch.flags & TF_kernel_mode;
+     old_shadow = update_cr3(v);
+@@ -478,15 +480,22 @@ static void _toggle_guest_pt(struct vcpu *v)
+     {
+         cr3 &= ~X86_CR3_NOFLUSH;
+ 
++        local_irq_disable();
+         if ( unlikely(mfn_eq(pagetable_get_mfn(old_shadow),
+                              maddr_to_mfn(cr3))) )
+         {
+-            cr3 = idle_vcpu[v->processor]->arch.cr3;
+             /* Also suppress runstate/time area updates below. */
+             guest_update = false;
++
++            cr3 = idle_vcpu[v->processor]->arch.cr3;
++            this_cpu(pgtable_vcpu) = idle_vcpu[v->processor];
+         }
++
++        write_cr3(cr3);
++        local_irq_enable();
+     }
+-    write_cr3(cr3);
++    else
++        write_cr3(cr3);
+ 
+     if ( !pagetable_is_null(old_shadow) )
+         shadow_put_top_level(v->domain, old_shadow);
+diff --git a/xen/arch/x86/smpboot.c b/xen/arch/x86/smpboot.c
+index 0b1c1c51c2..ed28e385fc 100644
+--- a/xen/arch/x86/smpboot.c
++++ b/xen/arch/x86/smpboot.c
+@@ -336,6 +336,7 @@ void start_secondary(void *unused)
+ 
+     set_current(idle_vcpu[cpu]);
+     this_cpu(curr_vcpu) = idle_vcpu[cpu];
++    this_cpu(pgtable_vcpu) = idle_vcpu[cpu];
+     rdmsrl(MSR_EFER, this_cpu(efer));
+     init_shadow_spec_ctrl_state();
+ 
+diff --git a/xen/common/efi/common-stub.c b/xen/common/efi/common-stub.c
+index 5a91fe28cc..aaeb916c0f 100644
+--- a/xen/common/efi/common-stub.c
++++ b/xen/common/efi/common-stub.c
+@@ -7,11 +7,6 @@ bool efi_enabled(unsigned int feature)
+     return false;
+ }
+ 
+-bool efi_rs_using_pgtables(void)
+-{
+-    return false;
+-}
+-
+ unsigned long efi_get_time(void)
+ {
+     BUG();
+diff --git a/xen/common/efi/runtime.c b/xen/common/efi/runtime.c
+index 13b0975866..a83dfaf3bf 100644
+--- a/xen/common/efi/runtime.c
++++ b/xen/common/efi/runtime.c
+@@ -46,7 +46,6 @@ const CHAR16 *__read_mostly efi_fw_vendor;
+ const EFI_RUNTIME_SERVICES *__read_mostly efi_rs;
+ #ifndef CONFIG_ARM /* TODO - disabled until implemented on ARM */
+ static DEFINE_SPINLOCK(efi_rs_lock);
+-static unsigned int efi_rs_on_cpu = NR_CPUS;
+ #endif
+ 
+ UINTN __read_mostly efi_memmap_size;
+@@ -89,6 +88,11 @@ struct efi_rs_state efi_rs_enter(void)
+     if ( mfn_eq(efi_l4_mfn, INVALID_MFN) )
+         return state;
+ 
++    /*
++     * If in lazy idle context switch state sync now to avoid an incoming
++     * FLUSH_VCPU_STATE IPI changing the loaded page-tables.
++     */
++    sync_local_execstate();
+     state.cr3 = read_cr3();
+     save_fpu_enable();
+     asm volatile ( "fnclex; fldcw %0" :: "m" (fcw) );
+@@ -96,8 +100,6 @@ struct efi_rs_state efi_rs_enter(void)
+ 
+     spin_lock(&efi_rs_lock);
+ 
+-    efi_rs_on_cpu = smp_processor_id();
+-
+     /* prevent fixup_page_fault() from doing anything */
+     irq_enter();
+ 
+@@ -112,7 +114,8 @@ struct efi_rs_state efi_rs_enter(void)
+         lgdt(&gdt_desc);
+     }
+ 
+-    switch_cr3_cr4(mfn_to_maddr(efi_l4_mfn), read_cr4());
++    switch_cr3_cr4(idle_vcpu[smp_processor_id()], mfn_to_maddr(efi_l4_mfn),
++                   read_cr4());
+ 
+     /*
+      * At the time of writing (2022), no UEFI firwmare is CET-IBT compatible.
+@@ -140,7 +143,7 @@ void efi_rs_leave(struct efi_rs_state *state)
+     if ( state->msr_s_cet )
+         wrmsrl(MSR_S_CET, state->msr_s_cet);
+ 
+-    switch_cr3_cr4(state->cr3, read_cr4());
++    switch_cr3_cr4(curr, state->cr3, read_cr4());
+     if ( is_pv_vcpu(curr) && !is_idle_vcpu(curr) )
+     {
+         struct desc_ptr gdt_desc = {
+@@ -151,18 +154,10 @@ void efi_rs_leave(struct efi_rs_state *state)
+         lgdt(&gdt_desc);
+     }
+     irq_exit();
+-    efi_rs_on_cpu = NR_CPUS;
+     spin_unlock(&efi_rs_lock);
+     vcpu_restore_fpu_nonlazy(curr, true);
+ }
+ 
+-bool efi_rs_using_pgtables(void)
+-{
+-    return !mfn_eq(efi_l4_mfn, INVALID_MFN) &&
+-           (smp_processor_id() == efi_rs_on_cpu) &&
+-           (read_cr3() == mfn_to_maddr(efi_l4_mfn));
+-}
+-
+ unsigned long efi_get_time(void)
+ {
+     EFI_TIME time;
+diff --git a/xen/include/xen/efi.h b/xen/include/xen/efi.h
+index 94a7e547f9..fe2f3b3941 100644
+--- a/xen/include/xen/efi.h
++++ b/xen/include/xen/efi.h
+@@ -34,7 +34,6 @@ struct compat_pf_efi_runtime_call;
+ bool efi_enabled(unsigned int feature);
+ void efi_init_memory(void);
+ bool efi_boot_mem_unused(unsigned long *start, unsigned long *end);
+-bool efi_rs_using_pgtables(void);
+ unsigned long efi_get_time(void);
+ void efi_halt_system(void);
+ void efi_reset_system(bool warm);
+-- 
+2.53.0
+

--- a/SOURCES/0001-xen-xsm-make-getdomaininfo-xsm-dummy-checks-more-str.patch
+++ b/SOURCES/0001-xen-xsm-make-getdomaininfo-xsm-dummy-checks-more-str.patch
@@ -1,0 +1,77 @@
+From 08b65866a485ded4815be46341c2b30190ac6bdf Mon Sep 17 00:00:00 2001
+From: Juergen Gross <jgross@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 01/18] xen/xsm: make getdomaininfo xsm dummy checks more
+ stringent
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Today the dummy XSM privilege checks for getdomaininfo are less
+stringent than possible: they basically rely on the general
+sysctl/domctl entry check to do all tests and then do the test with
+the XSM_HOOK privilege, which is an "allow all" default.
+
+Instead of XSM_HOOK use XSM_XS_PRIV, which is the privilege really
+wanted. Note that this test is still wider than the sysctl entry test,
+but there is no easy way to make both domctl and sysctl happy at the
+same time.
+
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+master commit: 5793b84c5e8fb268f94e7fde7816799e66945a73
+master date: 2024-12-16 13:06:55 +0100
+
+Backport notes:
+Backported to xen 4.17.6-9.1 from RELEASE-4.17.6
+Conflicts in xen/common/domctl.c due to a9dc384c64 (domctl: Modify
+XEN_DOMCTL_getdomaininfo to fail if domid is not found)
+
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+---
+ xen/common/domctl.c     | 2 +-
+ xen/common/sysctl.c     | 2 +-
+ xen/include/xsm/dummy.h | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index f40680c9cd..c9348c0d36 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -537,7 +537,7 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         break;
+ 
+     case XEN_DOMCTL_getdomaininfo:
+-        ret = xsm_getdomaininfo(XSM_HOOK, d);
++        ret = xsm_getdomaininfo(XSM_XS_PRIV, d);
+         if ( ret )
+             break;
+ 
+diff --git a/xen/common/sysctl.c b/xen/common/sysctl.c
+index 0cbfe8bd44..4c7551c5d9 100644
+--- a/xen/common/sysctl.c
++++ b/xen/common/sysctl.c
+@@ -89,7 +89,7 @@ long do_sysctl(XEN_GUEST_HANDLE_PARAM(xen_sysctl_t) u_sysctl)
+             if ( num_domains == op->u.getdomaininfolist.max_domains )
+                 break;
+ 
+-            if ( xsm_getdomaininfo(XSM_HOOK, d) )
++            if ( xsm_getdomaininfo(XSM_XS_PRIV, d) )
+                 continue;
+ 
+             getdomaininfo(d, &info);
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index a7267fdc14..1c56ccb014 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -137,7 +137,7 @@ static XSM_INLINE int cf_check xsm_domain_create(
+ static XSM_INLINE int cf_check xsm_getdomaininfo(
+     XSM_DEFAULT_ARG struct domain *d)
+ {
+-    XSM_ASSERT_ACTION(XSM_HOOK);
++    XSM_ASSERT_ACTION(XSM_XS_PRIV);
+     return xsm_default_action(action, current->domain, d);
+ }
+ 
+-- 
+2.53.0
+

--- a/SOURCES/0002-sched-use-sequence-counter-to-enlighten-vcpu_runstat.patch
+++ b/SOURCES/0002-sched-use-sequence-counter-to-enlighten-vcpu_runstat.patch
@@ -1,0 +1,315 @@
+From 5db41094021f809fcc50930414f2b8b2eb83d557 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 02/18] sched: use sequence counter to enlighten
+ vcpu_runstate_get()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Subsequently XEN_DOMCTL_getdomaininfo will want to invoke the function
+without holding a lock, thus allowing parallel execution of potentially
+many instances. As was learned from 228ab9992ffb ("domctl: improve
+locking during domain destruction"), reverted by d0887cc6b16e, such
+parallelism can result in severe lock contention on any (previously)
+inner lock. To avoid taking that risk replace the use of the scheduler
+lock in vcpu_runstate_get() by a newly introduced sequence counter.
+Convert the "no lock if current" property to "use a local counter
+instance", thus guaranteeing the loop to exit after the first iteration.
+
+Skeleton and commentary of the seqcount implementation based on /
+derived from Linux 6.11-rc.
+
+To have runstate_seq placed next to runstate in struct vcpu, without
+introducing a new obvious padding hole, yet while keeping the latter
+adjacent to runstate_guest{,_area} as well, move runstate down a little.
+
+This is part of XSA-492.
+
+Requested-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Juergen Gross <jgross@suse.com>
+
+Backport notes:
+Backported to 4.17.6-9.1 from RELEASE-4.17.6
+Conflicts in xen/common/sched/core.c due to extra commit 05e906b3bb
+(Track vcpu->nonaffine_time for each vCPU)
+
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Backported-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ xen/common/sched/core.c    |  69 +++++++++---------
+ xen/include/xen/sched.h    |   2 +
+ xen/include/xen/seqcount.h | 139 +++++++++++++++++++++++++++++++++++++
+ 3 files changed, 175 insertions(+), 35 deletions(-)
+ create mode 100644 xen/include/xen/seqcount.h
+
+diff --git a/xen/common/sched/core.c b/xen/common/sched/core.c
+index 63ba491664..716bf01caa 100644
+--- a/xen/common/sched/core.c
++++ b/xen/common/sched/core.c
+@@ -295,18 +295,22 @@ static inline void vcpu_runstate_change(
+     }
+ 
+     delta = new_entry_time - v->runstate.state_entry_time;
+-    if ( delta > 0 )
++
++    /* Serialization: ->schedule_lock (see ASSERT() above). */
++    with_seq_write(&v->runstate_seq)
+     {
+-        v->runstate.time[v->runstate.state] += delta;
++        if ( delta > 0 )
++        {
++            v->runstate.time[v->runstate.state] += delta;
++            v->runstate.state_entry_time = new_entry_time;
+ 
+-        if ( is_running_nonaffine(v, unit) )
+-            v->runstate_extra.nonaffine_time += delta;
++            if ( is_running_nonaffine(v, unit) )
++                v->runstate_extra.nonaffine_time += delta;
++        }
+ 
+-        v->runstate.state_entry_time = new_entry_time;
++        v->runstate.state = new_state;
+     }
+ 
+-    v->runstate.state = new_state;
+-
+     /* Update domain runstate */
+     if ( spin_trylock(&d->runstate_lock) )
+     {
+@@ -396,39 +400,34 @@ void sched_guest_idle(void (*idle) (void), unsigned int cpu)
+ struct vcpu_runstate_extra vcpu_runstate_get(
+     const struct vcpu *v, struct vcpu_runstate_info *runstate)
+ {
+-    spinlock_t *lock;
+-    s_time_t delta;
+-    struct sched_unit *unit;
+     struct vcpu_runstate_extra ret;
++    struct seqcount seq = SEQCNT_ZERO();
++    const struct seqcount *s = likely(v == current) ? &seq : &v->runstate_seq;
++
++    until_seq_read(s)
++    {
++        s_time_t delta;
++        struct sched_unit *unit = is_idle_vcpu(v) ?
++                                    get_sched_res(v->processor)->sched_unit_idle
++                                    : v->sched_unit;
++        spinlock_t *lock = likely(v == current) ?
++                                    NULL : unit_schedule_lock_irq(unit);
++
++        *runstate = v->runstate;
++        ret = v->runstate_extra;
++        delta = NOW() - runstate->state_entry_time;
++        if ( delta > 0 )
++        {
++            runstate->time[runstate->state] += delta;
+ 
+-    rcu_read_lock(&sched_res_rculock);
+-
+-    /*
+-     * Be careful in case of an idle vcpu: the assignment to a unit might
+-     * change even with the scheduling lock held, so be sure to use the
+-     * correct unit for locking in order to avoid triggering an ASSERT() in
+-     * the unlock function.
+-     */
+-    unit = is_idle_vcpu(v) ? get_sched_res(v->processor)->sched_unit_idle
+-                           : v->sched_unit;
+-    lock = likely(v == current) ? NULL : unit_schedule_lock_irq(unit);
+-    memcpy(runstate, &v->runstate, sizeof(*runstate));
+-    ret = v->runstate_extra;
+-
+-    delta = NOW() - runstate->state_entry_time;
+-    if ( delta > 0 )
+-    {
+-        runstate->time[runstate->state] += delta;
++            if ( is_running_nonaffine(v, unit) )
++                ret.nonaffine_time += delta;
++        }
+ 
+-        if ( is_running_nonaffine(v, unit) )
+-            ret.nonaffine_time += delta;
++        if ( unlikely(lock != NULL) )
++            unit_schedule_unlock_irq(lock, unit);
+     }
+ 
+-    if ( unlikely(lock != NULL) )
+-        unit_schedule_unlock_irq(lock, unit);
+-
+-    rcu_read_unlock(&sched_res_rculock);
+-
+     return ret;
+ }
+ 
+diff --git a/xen/include/xen/sched.h b/xen/include/xen/sched.h
+index 79ac24f5cb..97060e89d6 100644
+--- a/xen/include/xen/sched.h
++++ b/xen/include/xen/sched.h
+@@ -16,6 +16,7 @@
+ #include <xen/radix-tree.h>
+ #include <xen/multicall.h>
+ #include <xen/nospec.h>
++#include <xen/seqcount.h>
+ #include <xen/tasklet.h>
+ #include <xen/mm.h>
+ #include <xen/smp.h>
+@@ -214,6 +215,7 @@ struct vcpu
+         XEN_GUEST_HANDLE(vcpu_runstate_info_compat_t) compat;
+     } runstate_guest; /* guest address */
+ #endif
++    struct seqcount  runstate_seq;
+     unsigned int     new_state;
+ 
+     /* Has the FPU been initialised? */
+diff --git a/xen/include/xen/seqcount.h b/xen/include/xen/seqcount.h
+new file mode 100644
+index 0000000000..b5faf422e4
+--- /dev/null
++++ b/xen/include/xen/seqcount.h
+@@ -0,0 +1,139 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++#ifndef XEN_SEQCOUNT_H
++#define XEN_SEQCOUNT_H
++
++#include <xen/lib.h>
++#include <xen/nospec.h>
++
++#include <asm/atomic.h>
++#include <asm/system.h>
++
++/*
++ * Sequence counters (seqcount_t)
++ *
++ * This is the raw counting mechanism, without any writer protection.
++ *
++ * Write side critical sections must be serialized (and non-preemptible).
++ *
++ * If readers can be invoked from interrupt contexts, interrupts must also
++ * be respectively disabled before entering the write section.
++ *
++ * This mechanism can't be used if the protected data contains pointers,
++ * as the writer can invalidate a pointer that a reader is following.
++ */
++struct seqcount {
++    unsigned int sequence;
++};
++
++/*
++ * SEQCNT_ZERO() - initializer for seqcount_t
++ * @name: Name of the struct seqcount instance
++ */
++#define SEQCNT_ZERO() { .sequence = 0 }
++
++static inline unsigned int seqprop_sequence(const struct seqcount *s)
++{
++    return ACCESS_ONCE(s->sequence);
++}
++
++/*
++ * read_seqcount_begin() - begin a seqcount read critical section
++ * @s: Pointer to struct seqcount
++ *
++ * Return: count to be passed to read_seqcount_retry()
++ */
++static inline unsigned int _read_seqcount_begin(const struct seqcount *s)
++{
++    unsigned int seq;
++
++    while ((seq = seqprop_sequence(s)) & 1)
++        cpu_relax();
++
++    smp_rmb();
++
++    return seq;
++}
++
++static always_inline unsigned int read_seqcount_begin(const struct seqcount *s)
++{
++    unsigned int seq = _read_seqcount_begin(s);
++
++    block_lock_speculation();
++
++    return seq;
++}
++
++/*
++ * read_seqcount_retry() - end a seqcount read critical section
++ * @s: Pointer to struct seqcount
++ * @start: count, from read_seqcount_begin()
++ *
++ * read_seqcount_retry closes the read critical section of given struct
++ * seqcount.  If the critical section was invalid, it must be ignored
++ * (and typically retried).
++ *
++ * Return: true if a read section retry is required, else false
++ */
++static inline bool _read_seqcount_retry(const struct seqcount *s,
++                                        unsigned int start)
++{
++    smp_rmb();
++    return unlikely(seqprop_sequence(s) != start);
++}
++
++static always_inline bool read_seqcount_retry(const struct seqcount *s,
++                                              unsigned int start)
++{
++    return lock_evaluate_nospec(_read_seqcount_retry(s, start));
++}
++
++/* Loops until a consistent count has been observed across the loop body. */
++#define until_seq_read(seq)                                    \
++    for ( unsigned int retry_ = 1, count_;                     \
++          retry_ && (count_ = read_seqcount_begin(seq), true); \
++          retry_ = read_seqcount_retry(seq, count_) )
++
++/*
++ * write_seqcount_begin() - start a struct seqcount write side critical section
++ * @s: Pointer to struct seqcount
++ *
++ * Context: sequence counter write side sections must be serialized.
++ * If readers can be invoked from interrupt context, interrupts must be
++ * respectively disabled.
++ */
++static inline void write_seqcount_begin(struct seqcount *s)
++{
++    add_sized(&s->sequence, 1);
++    smp_wmb();
++}
++
++/*
++ * write_seqcount_end() - end a struct seqcount write side critical section
++ * @s: Pointer to seqcount
++ */
++static inline void write_seqcount_end(struct seqcount *s)
++{
++    smp_wmb();
++    add_sized(&s->sequence, 1);
++}
++
++/*
++ * Not really a loop, but we need write_seqcount_{begin,end}() in the correct
++ * position.
++ */
++#define with_seq_write(seq)                           \
++    for ( bool once_ = true;                          \
++          once_ && (write_seqcount_begin(seq), true); \
++          (write_seqcount_end(seq), once_ = false) )
++
++#endif /* XEN_SEQCOUNT_H */
++
++/*
++ * Local variables:
++ * mode: C
++ * c-file-style: "BSD"
++ * c-basic-offset: 4
++ * tab-width: 4
++ * indent-tabs-mode: nil
++ * End:
++ */
+-- 
+2.53.0
+

--- a/SOURCES/0003-domctl-handle-XEN_DOMCTL_getdomaininfo-without-acqui.patch
+++ b/SOURCES/0003-domctl-handle-XEN_DOMCTL_getdomaininfo-without-acqui.patch
@@ -1,0 +1,128 @@
+From a5ea65b33f9350f5d24f3d169777d7efa1a63bb5 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 03/18] domctl: handle XEN_DOMCTL_getdomaininfo without
+ acquiring domctl lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+getdomaininfo() is not called under consistently the same lock. Thus,
+with caller side locking irrelevant, it can as well be called with the
+domctl lock not held. (Callers not pausing the domain they want to
+retrieve information for already need to be aware that not all of the
+data returned can be relied on as being consistent; most data will also
+be stale by the time the caller gets to look at it.)
+
+Move the handling not only ahead of acquiring the lock, but also ahead
+of the XSM check, leveraging that the sub-op has its own hook.
+
+This is part of XSA-492.
+
+Fixes: 5513bd0b4675 ("add xenstore domain flag to hypervisor")
+Reported-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+
+Backport notes:
+Backported to xen 4.17.6-9.1 from RELEASE-4.17.6
+Conflicts in xen/common/domctl.c due to a9dc384c64 ("domctl: Modify
+XEN_DOMCTL_getdomaininfo to fail if domid is not found").
+
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Backported-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ xen/common/domctl.c     | 30 +++++++++++++++++++-----------
+ xen/include/xsm/dummy.h |  5 ++++-
+ xen/xsm/flask/hooks.c   |  6 +++++-
+ 3 files changed, 28 insertions(+), 13 deletions(-)
+
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index c9348c0d36..2c49d63a84 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -319,6 +319,25 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+             return -ESRCH;
+     }
+ 
++    /* Handle sub-ops not requiring the domctl lock. */
++    switch ( op->cmd )
++    {
++    case XEN_DOMCTL_getdomaininfo:
++        ret = xsm_getdomaininfo(XSM_XS_PRIV, d);
++        if ( ret )
++            goto domctl_out_unlock_domonly;
++
++        getdomaininfo(d, &op->u.getdomaininfo);
++
++        op->domain = op->u.getdomaininfo.domain;
++        copyback = 1;
++        goto domctl_out_unlock_domonly;
++
++    default:
++        /* Everything else handled further down. */
++        break;
++    }
++
+     ret = xsm_domctl(XSM_OTHER, d, op->cmd,
+                      /* SSIDRef only applicable for cmd == createdomain */
+                      op->u.createdomain.ssidref);
+@@ -536,17 +555,6 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         copyback = 1;
+         break;
+ 
+-    case XEN_DOMCTL_getdomaininfo:
+-        ret = xsm_getdomaininfo(XSM_XS_PRIV, d);
+-        if ( ret )
+-            break;
+-
+-        getdomaininfo(d, &op->u.getdomaininfo);
+-
+-        op->domain = op->u.getdomaininfo.domain;
+-        copyback = 1;
+-        break;
+-
+     case XEN_DOMCTL_getvcpucontext:
+     {
+         vcpu_guest_context_u c = { .nat = NULL };
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index 1c56ccb014..d5da82b011 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -172,8 +172,11 @@ static XSM_INLINE int cf_check xsm_domctl(
+     case XEN_DOMCTL_bind_pt_irq:
+     case XEN_DOMCTL_unbind_pt_irq:
+         return xsm_default_action(XSM_DM_PRIV, current->domain, d);
++
+     case XEN_DOMCTL_getdomaininfo:
+-        return xsm_default_action(XSM_XS_PRIV, current->domain, d);
++        ASSERT_UNREACHABLE();
++        return -EILSEQ;
++
+     default:
+         return xsm_default_action(XSM_PRIV, current->domain, d);
+     }
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index 2737c4f2cc..dcc040b31c 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -678,8 +678,12 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+          */
+         return avc_current_has_perm(ssidref, SECCLASS_DOMAIN, DOMAIN__CREATE, NULL);
+ 
+-    /* These have individual XSM hooks (common/domctl.c) */
++    /* These have individual XSM hooks and don't make it here. */
+     case XEN_DOMCTL_getdomaininfo:
++        ASSERT_UNREACHABLE();
++        return -EILSEQ;
++
++    /* These have individual XSM hooks (common/domctl.c) */
+     case XEN_DOMCTL_scheduler_op:
+     case XEN_DOMCTL_irq_permission:
+     case XEN_DOMCTL_iomem_permission:
+-- 
+2.53.0
+

--- a/SOURCES/0004-domain-locking-for-iomem_caps-accesses.patch
+++ b/SOURCES/0004-domain-locking-for-iomem_caps-accesses.patch
@@ -1,0 +1,190 @@
+From 0b02753566fc7084ff4df2dc20164892686f4237 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 04/18] domain: locking for iomem_caps accesses
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+In order to be able to pull at least the XEN_DOMCTL_iomem_mapping handling
+out of the domctl-locked region, a separate (per-domain) lock is needed to
+synchronize in particular with XEN_DOMCTL_iomem_permission.
+
+Locking is added only as far as domctl-s are affected. Uses presently
+outside of the domctl lock may want dealing with subsequently (perhaps
+limited to non-__init code).
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+
+Backport notes:
+Backported to 4.17.6-9.1 from RELEASE-4.17.6
+Conflicts in xen/common/domain.c due to 49366ea8a958:("Hypercall to
+obtain aggregated domain runstate information, and bindings.") and the
+extra spin_lock_init(&d->runstate_lock) in the context for
+domain_create().
+
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Backported-by: Quentin Casasnovas <quentin.casasnovas@vates.tech>
+---
+ xen/common/domain.c     |  6 +++++
+ xen/common/domctl.c     | 53 ++++++++++++++++++++++++++++++++---------
+ xen/include/xen/iocap.h |  3 +++
+ xen/include/xen/sched.h |  1 +
+ 4 files changed, 52 insertions(+), 11 deletions(-)
+
+diff --git a/xen/common/domain.c b/xen/common/domain.c
+index a7dc60a00d..595d1078ff 100644
+--- a/xen/common/domain.c
++++ b/xen/common/domain.c
+@@ -332,10 +332,15 @@ static int late_hwdom_init(struct domain *d)
+      * may be modified after this hypercall returns if a more complex
+      * device model is desired.
+      */
++    write_lock(&dom0->caps_lock);
+     rangeset_swap(d->irq_caps, dom0->irq_caps);
+     rangeset_swap(d->iomem_caps, dom0->iomem_caps);
+ #ifdef CONFIG_X86
+     rangeset_swap(d->arch.ioport_caps, dom0->arch.ioport_caps);
++#endif
++    write_unlock(&dom0->caps_lock);
++
++#ifdef CONFIG_X86
+     setup_io_bitmap(d);
+     setup_io_bitmap(dom0);
+ #endif
+@@ -619,6 +624,7 @@ struct domain *domain_create(domid_t domid,
+     spin_lock_init_prof(d, page_alloc_lock);
+     spin_lock_init(&d->hypercall_deadlock_mutex);
+     spin_lock_init(&d->runstate_lock);
++    rwlock_init(&d->caps_lock);
+     INIT_PAGE_LIST_HEAD(&d->page_list);
+     INIT_PAGE_LIST_HEAD(&d->extra_page_list);
+     INIT_PAGE_LIST_HEAD(&d->xenpage_list);
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index 2c49d63a84..b65a88f483 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -278,6 +278,35 @@ static struct vnuma_info *vnuma_init(const struct xen_domctl_vnuma *uinfo,
+     return ERR_PTR(ret);
+ }
+ 
++void iocaps_double_lock(struct domain *d, bool write)
++{
++    struct domain *currd = current->domain;
++
++    if ( d->domain_id > currd->domain_id )
++        read_lock(&currd->caps_lock);
++
++    if ( write )
++        write_lock(&d->caps_lock);
++    else
++        read_lock(&d->caps_lock);
++
++    if ( d->domain_id < currd->domain_id )
++        read_lock(&currd->caps_lock);
++}
++
++void iocaps_double_unlock(struct domain *d, bool write)
++{
++    struct domain *currd = current->domain;
++
++    if ( d != currd )
++        read_unlock(&currd->caps_lock);
++
++    if ( write )
++        write_unlock(&d->caps_lock);
++    else
++        read_unlock(&d->caps_lock);
++}
++
+ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+ {
+     long ret = 0;
+@@ -690,6 +719,8 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         if ( (mfn + nr_mfns - 1) < mfn ) /* wrap? */
+             break;
+ 
++        iocaps_double_lock(d, true);
++
+         if ( !iomem_access_permitted(current->domain,
+                                      mfn, mfn + nr_mfns - 1) ||
+              xsm_iomem_permission(XSM_HOOK, d, mfn, mfn + nr_mfns - 1, allow) )
+@@ -698,6 +729,8 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+             ret = iomem_permit_access(d, mfn, mfn + nr_mfns - 1);
+         else
+             ret = iomem_deny_access(d, mfn, mfn + nr_mfns - 1);
++
++        iocaps_double_unlock(d, true);
+         break;
+     }
+ 
+@@ -722,19 +755,15 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+             break;
+ #endif
+ 
++        iocaps_double_lock(d, false);
++
+         ret = -EPERM;
+         if ( !iomem_access_permitted(current->domain, mfn, mfn_end) ||
+-             !iomem_access_permitted(d, mfn, mfn_end) )
+-            break;
+-
+-        ret = xsm_iomem_mapping(XSM_HOOK, d, mfn, mfn_end, add);
+-        if ( ret )
+-            break;
+-
+-        if ( !paging_mode_translate(d) )
+-            break;
+-
+-        if ( add )
++             !iomem_access_permitted(d, mfn, mfn_end) ||
++             (ret = xsm_iomem_mapping(XSM_HOOK, d, mfn, mfn_end, add)) ||
++             !paging_mode_translate(d) )
++            /* Nothing. */;
++        else if ( add )
+         {
+             printk(XENLOG_G_DEBUG
+                    "memory_map:add: dom%d gfn=%lx mfn=%lx nr=%lx\n",
+@@ -758,6 +787,8 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+                        "memory_map: error %ld removing dom%d access to [%lx,%lx]\n",
+                        ret, d->domain_id, mfn, mfn_end);
+         }
++
++        iocaps_double_unlock(d, false);
+         break;
+     }
+ 
+diff --git a/xen/include/xen/iocap.h b/xen/include/xen/iocap.h
+index ffbc48b60f..cb36ebbeeb 100644
+--- a/xen/include/xen/iocap.h
++++ b/xen/include/xen/iocap.h
+@@ -12,6 +12,9 @@
+ #include <asm/iocap.h>
+ #include <asm/p2m.h>
+ 
++void iocaps_double_lock(struct domain *d, bool write);
++void iocaps_double_unlock(struct domain *d, bool write);
++
+ static inline int iomem_permit_access(struct domain *d, unsigned long s,
+                                       unsigned long e)
+ {
+diff --git a/xen/include/xen/sched.h b/xen/include/xen/sched.h
+index 97060e89d6..1721e70c3d 100644
+--- a/xen/include/xen/sched.h
++++ b/xen/include/xen/sched.h
+@@ -506,6 +506,7 @@ struct domain
+ #endif
+ 
+     /* I/O capabilities (access to IRQs and memory-mapped I/O). */
++    rwlock_t         caps_lock;
+     struct rangeset *iomem_caps;
+     struct rangeset *irq_caps;
+ 
+-- 
+2.53.0
+

--- a/SOURCES/0005-x86-domain-locking-for-ioport_caps-accesses.patch
+++ b/SOURCES/0005-x86-domain-locking-for-ioport_caps-accesses.patch
@@ -1,0 +1,103 @@
+From aff096eb57c3be0c642dd2a0c59a29a5c3d0a8f4 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 05/18] x86/domain: locking for ioport_caps accesses
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+In order to be able to pull at least the XEN_DOMCTL_ioport_mapping
+handling out of the domctl-locked region, the new separate (per-domain)
+lock is used to synchronize in particular with
+XEN_DOMCTL_ioport_permission.
+
+Locking is added only as far as domctl-s are affected. Uses presently
+outside of the domctl lock may want dealing with subsequently (perhaps
+limited to non-__init code).
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+---
+ xen/arch/x86/domctl.c | 21 ++++++++++++---------
+ xen/arch/x86/setup.c  |  4 ++++
+ 2 files changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/xen/arch/x86/domctl.c b/xen/arch/x86/domctl.c
+index 67dc26dce7..0359e490de 100644
+--- a/xen/arch/x86/domctl.c
++++ b/xen/arch/x86/domctl.c
+@@ -249,6 +249,8 @@ long arch_do_domctl(
+         unsigned int np = domctl->u.ioport_permission.nr_ports;
+         int allow = domctl->u.ioport_permission.allow_access;
+ 
++        iocaps_double_lock(d, true);
++
+         if ( (fp + np) <= fp || (fp + np) > MAX_IOPORTS )
+             ret = -EINVAL;
+         else if ( !ioports_access_permitted(currd, fp, fp + np - 1) ||
+@@ -258,6 +260,8 @@ long arch_do_domctl(
+             ret = ioports_permit_access(d, fp, fp + np - 1);
+         else
+             ret = ioports_deny_access(d, fp, fp + np - 1);
++
++        iocaps_double_unlock(d, true);
+         break;
+     }
+ 
+@@ -628,16 +632,13 @@ long arch_do_domctl(
+             break;
+         }
+ 
+-        ret = -EPERM;
+-        if ( !ioports_access_permitted(currd, fmp, fmp + np - 1) )
+-            break;
+-
+-        ret = xsm_ioport_mapping(XSM_HOOK, d, fmp, fmp + np - 1, add);
+-        if ( ret )
+-            break;
+-
+         hvm = &d->arch.hvm;
+-        if ( add )
++        iocaps_double_lock(d, true);
++
++        if ( !ioports_access_permitted(currd, fmp, fmp + np - 1) ||
++             (ret = xsm_ioport_mapping(XSM_HOOK, d, fmp, fmp + np - 1, add)) )
++            ret = ret ?: -EPERM;
++        else if ( add )
+         {
+             printk(XENLOG_G_INFO
+                    "ioport_map:add: dom%d gport=%x mport=%x nr=%x\n",
+@@ -698,6 +699,8 @@ long arch_do_domctl(
+                        "ioport_map: error %ld denying dom%d access to [%x,%x]\n",
+                        ret, d->domain_id, fmp, fmp + np - 1);
+         }
++
++        iocaps_double_unlock(d, true);
+         break;
+     }
+ 
+diff --git a/xen/arch/x86/setup.c b/xen/arch/x86/setup.c
+index 1768852f6e..2ebc3db2e2 100644
+--- a/xen/arch/x86/setup.c
++++ b/xen/arch/x86/setup.c
+@@ -2187,9 +2187,13 @@ void __hwdom_init setup_io_bitmap(struct domain *d)
+     if ( is_hvm_domain(d) )
+     {
+         bitmap_fill(d->arch.hvm.io_bitmap, 0x10000);
++
++        read_lock(&d->caps_lock);
+         rc = rangeset_report_ranges(d->arch.ioport_caps, 0, 0x10000,
+                                     io_bitmap_cb, d);
+         BUG_ON(rc);
++        read_unlock(&d->caps_lock);
++
+         /*
+          * NB: we need to trap accesses to 0xcf8 in order to intercept
+          * 4 byte accesses, that need to be handled by Xen in order to
+-- 
+2.53.0
+

--- a/SOURCES/0006-domain-locking-for-irq_caps-accesses.patch
+++ b/SOURCES/0006-domain-locking-for-irq_caps-accesses.patch
@@ -1,0 +1,201 @@
+From 39df54e474254dfc71f900c4efe151bf5ccea067 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 06/18] domain: locking for irq_caps accesses
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+In order to be able to pull at least the XEN_DOMCTL_{,un}bind_pt_irq
+handling out of the domctl-locked region, a separate (per-domain) lock is
+needed to synchronize in particular with XEN_DOMCTL_irq_permission.
+
+Locking is added only as far as domctl-s are affected. Uses presently
+outside of the domctl lock may want dealing with subsequently (perhaps
+limited to non-__init code).
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Julien Grall <julien@xen.org>
+---
+ xen/arch/arm/domctl.c | 37 +++++++++++++++++++++----------------
+ xen/arch/x86/domctl.c | 42 ++++++++++++++++++++++++++----------------
+ xen/common/domctl.c   |  5 +++++
+ 3 files changed, 52 insertions(+), 32 deletions(-)
+
+diff --git a/xen/arch/arm/domctl.c b/xen/arch/arm/domctl.c
+index 7920f4b689..17ae157ff9 100644
+--- a/xen/arch/arm/domctl.c
++++ b/xen/arch/arm/domctl.c
+@@ -79,6 +79,7 @@ long arch_do_domctl(struct xen_domctl *domctl, struct domain *d,
+     case XEN_DOMCTL_bind_pt_irq:
+     {
+         int rc;
++        struct domain *currd = current->domain;
+         struct xen_domctl_bind_pt_irq *bind = &domctl->u.bind_pt_irq;
+         uint32_t irq = bind->u.spi.spi;
+         uint32_t virq = bind->machine_irq;
+@@ -110,21 +111,26 @@ long arch_do_domctl(struct xen_domctl *domctl, struct domain *d,
+         if ( rc )
+             return rc;
+ 
+-        if ( !irq_access_permitted(current->domain, irq) )
+-            return -EPERM;
++        read_lock(&currd->caps_lock);
+ 
+-        if ( !vgic_reserve_virq(d, virq) )
+-            return -EBUSY;
+-
+-        rc = route_irq_to_guest(d, virq, irq, "routed IRQ");
+-        if ( rc )
+-            vgic_free_virq(d, virq);
++        if ( !irq_access_permitted(currd, irq) )
++            rc = -EPERM;
++        else if ( !vgic_reserve_virq(d, virq) )
++            rc = -EBUSY;
++        else
++        {
++            rc = route_irq_to_guest(d, virq, irq, "routed IRQ");
++            if ( rc )
++                vgic_free_virq(d, virq);
++        }
+ 
++        read_unlock(&currd->caps_lock);
+         return rc;
+     }
+     case XEN_DOMCTL_unbind_pt_irq:
+     {
+         int rc;
++        struct domain *currd = current->domain;
+         struct xen_domctl_bind_pt_irq *bind = &domctl->u.bind_pt_irq;
+         uint32_t irq = bind->u.spi.spi;
+         uint32_t virq = bind->machine_irq;
+@@ -141,16 +147,15 @@ long arch_do_domctl(struct xen_domctl *domctl, struct domain *d,
+         if ( rc )
+             return rc;
+ 
+-        if ( !irq_access_permitted(current->domain, irq) )
+-            return -EPERM;
++        read_lock(&currd->caps_lock);
+ 
+-        rc = release_guest_irq(d, virq);
+-        if ( rc )
+-            return rc;
+-
+-        vgic_free_virq(d, virq);
++        if ( !irq_access_permitted(currd, irq) )
++            rc = -EPERM;
++        else if ( !(rc = release_guest_irq(d, virq)) )
++            vgic_free_virq(d, virq);
+ 
+-        return 0;
++        read_unlock(&currd->caps_lock);
++        return rc;
+     }
+ 
+     case XEN_DOMCTL_vuart_op:
+diff --git a/xen/arch/x86/domctl.c b/xen/arch/x86/domctl.c
+index 0359e490de..2e57c038de 100644
+--- a/xen/arch/x86/domctl.c
++++ b/xen/arch/x86/domctl.c
+@@ -559,20 +559,27 @@ long arch_do_domctl(
+             break;
+ 
+         irq = domain_pirq_to_irq(d, bind->machine_irq);
+-        ret = -EPERM;
+-        if ( irq <= 0 || !irq_access_permitted(currd, irq) )
+-            break;
++        if ( irq <= 0 )
++            ret = -EPERM;
+ 
+-        ret = -ESRCH;
+-        if ( is_iommu_enabled(d) )
++        read_lock(&currd->caps_lock);
++
++        if ( !irq_access_permitted(currd, irq) )
++            ret = -EPERM;
++        else if ( is_iommu_enabled(d) )
+         {
+             pcidevs_lock();
+             ret = pt_irq_create_bind(d, bind);
+             pcidevs_unlock();
++
++            if ( ret < 0 )
++                printk(XENLOG_G_ERR "pt_irq_create_bind failed (%ld) for %pd\n",
++                       ret, d);
+         }
+-        if ( ret < 0 )
+-            printk(XENLOG_G_ERR "pt_irq_create_bind failed (%ld) for dom%d\n",
+-                   ret, d->domain_id);
++        else
++            ret = -ESRCH;
++
++        read_unlock(&currd->caps_lock);
+         break;
+     }
+ 
+@@ -585,23 +592,26 @@ long arch_do_domctl(
+         if ( !is_hvm_domain(d) )
+             break;
+ 
+-        ret = -EPERM;
+-        if ( irq <= 0 || !irq_access_permitted(currd, irq) )
+-            break;
+-
+         ret = xsm_unbind_pt_irq(XSM_HOOK, d, bind);
+         if ( ret )
+             break;
+ 
+-        if ( is_iommu_enabled(d) )
++        read_lock(&currd->caps_lock);
++
++        if ( !irq_access_permitted(currd, irq) )
++            ret = -EPERM;
++        else if ( is_iommu_enabled(d) )
+         {
+             pcidevs_lock();
+             ret = pt_irq_destroy_bind(d, bind);
+             pcidevs_unlock();
++
++            if ( ret < 0 )
++                printk(XENLOG_G_ERR "pt_irq_destroy_bind failed (%ld) for %pd\n",
++                       ret, d);
+         }
+-        if ( ret < 0 )
+-            printk(XENLOG_G_ERR "pt_irq_destroy_bind failed (%ld) for dom%d\n",
+-                   ret, d->domain_id);
++
++        read_unlock(&currd->caps_lock);
+         break;
+     }
+ 
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index b65a88f483..fea64cf274 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -699,6 +699,9 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+             ret = -EINVAL;
+             break;
+         }
++
++        iocaps_double_lock(d, true);
++
+         irq = pirq_access_permitted(current->domain, pirq);
+         if ( !irq || xsm_irq_permission(XSM_HOOK, d, irq, allow) )
+             ret = -EPERM;
+@@ -706,6 +709,8 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+             ret = irq_permit_access(d, irq);
+         else
+             ret = irq_deny_access(d, irq);
++
++        iocaps_double_unlock(d, true);
+         break;
+     }
+ 
+-- 
+2.53.0
+

--- a/SOURCES/0007-domctl-handle-XEN_DOMCTL_memory_mapping-without-acqu.patch
+++ b/SOURCES/0007-domctl-handle-XEN_DOMCTL_memory_mapping-without-acqu.patch
@@ -1,0 +1,215 @@
+From eeaff9fe8005aea4d18bb5b0367e62c29b2c4ba4 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 07/18] domctl: handle XEN_DOMCTL_memory_mapping without
+ acquiring domctl lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+With dedicated locking added, the domctl lock isn't required here anymore.
+Move the re-purposed dedicated XSM check as early as possible.
+
+Minimal "modernization": Switch "add" to bool and use %pd in log messages.
+
+This is part of XSA-492.
+
+Fixes: fda49f9b3fbb ("Add build option to allow more hypercalls from stubdoms")
+Reported-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+---
+ xen/common/domctl.c     | 118 ++++++++++++++++++++--------------------
+ xen/include/xsm/dummy.h |   4 +-
+ xen/xsm/flask/hooks.c   |   2 +-
+ 3 files changed, 63 insertions(+), 61 deletions(-)
+
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index fea64cf274..93494c2941 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -362,6 +362,66 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         copyback = 1;
+         goto domctl_out_unlock_domonly;
+ 
++    case XEN_DOMCTL_memory_mapping:
++    {
++        unsigned long gfn = op->u.memory_mapping.first_gfn;
++        unsigned long mfn = op->u.memory_mapping.first_mfn;
++        unsigned long nr_mfns = op->u.memory_mapping.nr_mfns;
++        unsigned long mfn_end = mfn + nr_mfns - 1;
++        bool add = op->u.memory_mapping.add_mapping;
++
++        ret = -EINVAL;
++        if ( mfn_end < mfn || /* Wrap? */
++             ((mfn | mfn_end) >> (paddr_bits - PAGE_SHIFT)) ||
++             (gfn + nr_mfns - 1) < gfn ) /* Wrap? */
++            goto domctl_out_unlock_domonly;
++
++        ret = xsm_iomem_mapping(XSM_DM_PRIV, d, mfn, mfn_end, add);
++        if ( ret || !paging_mode_translate(d) )
++            goto domctl_out_unlock_domonly;
++
++#ifndef CONFIG_X86 /* XXX ARM!? */
++        ret = -E2BIG;
++        /* Must break hypercall up as this could take a while. */
++        if ( nr_mfns > 64 )
++            goto domctl_out_unlock_domonly;
++#endif
++
++        iocaps_double_lock(d, false);
++
++        ret = -EPERM;
++        if ( !iomem_access_permitted(current->domain, mfn, mfn_end) ||
++             !iomem_access_permitted(d, mfn, mfn_end) )
++            /* Nothing. */;
++        else if ( add )
++        {
++            printk(XENLOG_G_DEBUG
++                   "memory_map:add: %pd gfn=%lx mfn=%lx nr=%lx\n",
++                   d, gfn, mfn, nr_mfns);
++
++            ret = map_mmio_regions(d, _gfn(gfn), nr_mfns, _mfn(mfn));
++            if ( ret < 0 )
++                printk(XENLOG_G_WARNING
++                       "memory_map:fail: %pd gfn=%lx mfn=%lx nr=%lx ret:%ld\n",
++                       d, gfn, mfn, nr_mfns, ret);
++        }
++        else
++        {
++            printk(XENLOG_G_DEBUG
++                   "memory_map:remove: %pd gfn=%lx mfn=%lx nr=%lx\n",
++                   d, gfn, mfn, nr_mfns);
++
++            ret = unmap_mmio_regions(d, _gfn(gfn), nr_mfns, _mfn(mfn));
++            if ( ret < 0 && is_hardware_domain(current->domain) )
++                printk(XENLOG_ERR
++                       "memory_map: error %ld removing %pd access to [%lx,%lx]\n",
++                       ret, d, mfn, mfn_end);
++        }
++
++        iocaps_double_unlock(d, false);
++        goto domctl_out_unlock_domonly;
++    }
++
+     default:
+         /* Everything else handled further down. */
+         break;
+@@ -739,64 +799,6 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         break;
+     }
+ 
+-    case XEN_DOMCTL_memory_mapping:
+-    {
+-        unsigned long gfn = op->u.memory_mapping.first_gfn;
+-        unsigned long mfn = op->u.memory_mapping.first_mfn;
+-        unsigned long nr_mfns = op->u.memory_mapping.nr_mfns;
+-        unsigned long mfn_end = mfn + nr_mfns - 1;
+-        int add = op->u.memory_mapping.add_mapping;
+-
+-        ret = -EINVAL;
+-        if ( mfn_end < mfn || /* wrap? */
+-             ((mfn | mfn_end) >> (paddr_bits - PAGE_SHIFT)) ||
+-             (gfn + nr_mfns - 1) < gfn ) /* wrap? */
+-            break;
+-
+-#ifndef CONFIG_X86 /* XXX ARM!? */
+-        ret = -E2BIG;
+-        /* Must break hypercall up as this could take a while. */
+-        if ( nr_mfns > 64 )
+-            break;
+-#endif
+-
+-        iocaps_double_lock(d, false);
+-
+-        ret = -EPERM;
+-        if ( !iomem_access_permitted(current->domain, mfn, mfn_end) ||
+-             !iomem_access_permitted(d, mfn, mfn_end) ||
+-             (ret = xsm_iomem_mapping(XSM_HOOK, d, mfn, mfn_end, add)) ||
+-             !paging_mode_translate(d) )
+-            /* Nothing. */;
+-        else if ( add )
+-        {
+-            printk(XENLOG_G_DEBUG
+-                   "memory_map:add: dom%d gfn=%lx mfn=%lx nr=%lx\n",
+-                   d->domain_id, gfn, mfn, nr_mfns);
+-
+-            ret = map_mmio_regions(d, _gfn(gfn), nr_mfns, _mfn(mfn));
+-            if ( ret < 0 )
+-                printk(XENLOG_G_WARNING
+-                       "memory_map:fail: dom%d gfn=%lx mfn=%lx nr=%lx ret:%ld\n",
+-                       d->domain_id, gfn, mfn, nr_mfns, ret);
+-        }
+-        else
+-        {
+-            printk(XENLOG_G_DEBUG
+-                   "memory_map:remove: dom%d gfn=%lx mfn=%lx nr=%lx\n",
+-                   d->domain_id, gfn, mfn, nr_mfns);
+-
+-            ret = unmap_mmio_regions(d, _gfn(gfn), nr_mfns, _mfn(mfn));
+-            if ( ret < 0 && is_hardware_domain(current->domain) )
+-                printk(XENLOG_ERR
+-                       "memory_map: error %ld removing dom%d access to [%lx,%lx]\n",
+-                       ret, d->domain_id, mfn, mfn_end);
+-        }
+-
+-        iocaps_double_unlock(d, false);
+-        break;
+-    }
+-
+     case XEN_DOMCTL_settimeoffset:
+         domain_set_time_offset(d, op->u.settimeoffset.time_offset_seconds);
+         break;
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index d5da82b011..b53312bb39 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -168,12 +168,12 @@ static XSM_INLINE int cf_check xsm_domctl(
+     switch ( cmd )
+     {
+     case XEN_DOMCTL_ioport_mapping:
+-    case XEN_DOMCTL_memory_mapping:
+     case XEN_DOMCTL_bind_pt_irq:
+     case XEN_DOMCTL_unbind_pt_irq:
+         return xsm_default_action(XSM_DM_PRIV, current->domain, d);
+ 
+     case XEN_DOMCTL_getdomaininfo:
++    case XEN_DOMCTL_memory_mapping:
+         ASSERT_UNREACHABLE();
+         return -EILSEQ;
+ 
+@@ -575,7 +575,7 @@ static XSM_INLINE int cf_check xsm_iomem_permission(
+ static XSM_INLINE int cf_check xsm_iomem_mapping(
+     XSM_DEFAULT_ARG struct domain *d, uint64_t s, uint64_t e, uint8_t allow)
+ {
+-    XSM_ASSERT_ACTION(XSM_HOOK);
++    XSM_ASSERT_ACTION(XSM_DM_PRIV);
+     return xsm_default_action(action, current->domain, d);
+ }
+ 
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index dcc040b31c..12350834ed 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -680,6 +680,7 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+ 
+     /* These have individual XSM hooks and don't make it here. */
+     case XEN_DOMCTL_getdomaininfo:
++    case XEN_DOMCTL_memory_mapping:
+         ASSERT_UNREACHABLE();
+         return -EILSEQ;
+ 
+@@ -687,7 +688,6 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+     case XEN_DOMCTL_scheduler_op:
+     case XEN_DOMCTL_irq_permission:
+     case XEN_DOMCTL_iomem_permission:
+-    case XEN_DOMCTL_memory_mapping:
+     case XEN_DOMCTL_set_target:
+     case XEN_DOMCTL_vm_event_op:
+ 
+-- 
+2.53.0
+

--- a/SOURCES/0008-domctl-handle-XEN_DOMCTL_ioport_mapping-without-acqu.patch
+++ b/SOURCES/0008-domctl-handle-XEN_DOMCTL_ioport_mapping-without-acqu.patch
@@ -1,0 +1,121 @@
+From 53566b6874372d89e1b1c9f8c135aa01e2cf61a2 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 08/18] domctl: handle XEN_DOMCTL_ioport_mapping without
+ acquiring domctl lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+With dedicated locking added, the domctl lock isn't required here anymore.
+As the handling is in arch-specific code (x86 only), almost no code is
+being moved, but a 2nd (extensible to other sub-ops) invocation of
+arch_do_domctl() is being added. Move just the re-purposed dedicated XSM
+check as early as possible.
+
+In flask_domctl() don't put #ifdef around the moved case label.
+
+This is part of XSA-492.
+
+Fixes: fda49f9b3fbb ("Add build option to allow more hypercalls from stubdoms")
+Reported-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+---
+ xen/arch/x86/domctl.c   | 9 ++++++---
+ xen/common/domctl.c     | 4 ++++
+ xen/include/xsm/dummy.h | 4 ++--
+ xen/xsm/flask/hooks.c   | 2 +-
+ 4 files changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/xen/arch/x86/domctl.c b/xen/arch/x86/domctl.c
+index 2e57c038de..94922dad21 100644
+--- a/xen/arch/x86/domctl.c
++++ b/xen/arch/x86/domctl.c
+@@ -642,12 +642,15 @@ long arch_do_domctl(
+             break;
+         }
+ 
++        ret = xsm_ioport_mapping(XSM_DM_PRIV, d, fmp, fmp + np - 1, add);
++        if ( ret )
++            break;
++
+         hvm = &d->arch.hvm;
+         iocaps_double_lock(d, true);
+ 
+-        if ( !ioports_access_permitted(currd, fmp, fmp + np - 1) ||
+-             (ret = xsm_ioport_mapping(XSM_HOOK, d, fmp, fmp + np - 1, add)) )
+-            ret = ret ?: -EPERM;
++        if ( !ioports_access_permitted(currd, fmp, fmp + np - 1) )
++            ret = -EPERM;
+         else if ( add )
+         {
+             printk(XENLOG_G_INFO
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index 93494c2941..051be67c69 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -422,6 +422,10 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         goto domctl_out_unlock_domonly;
+     }
+ 
++    case XEN_DOMCTL_ioport_mapping:
++        ret = arch_do_domctl(op, d, u_domctl);
++        goto domctl_out_unlock_domonly;
++
+     default:
+         /* Everything else handled further down. */
+         break;
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index b53312bb39..68fdd2157f 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -167,12 +167,12 @@ static XSM_INLINE int cf_check xsm_domctl(
+     XSM_ASSERT_ACTION(XSM_OTHER);
+     switch ( cmd )
+     {
+-    case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_bind_pt_irq:
+     case XEN_DOMCTL_unbind_pt_irq:
+         return xsm_default_action(XSM_DM_PRIV, current->domain, d);
+ 
+     case XEN_DOMCTL_getdomaininfo:
++    case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_memory_mapping:
+         ASSERT_UNREACHABLE();
+         return -EILSEQ;
+@@ -771,7 +771,7 @@ static XSM_INLINE int cf_check xsm_ioport_permission(
+ static XSM_INLINE int cf_check xsm_ioport_mapping(
+     XSM_DEFAULT_ARG struct domain *d, uint32_t s, uint32_t e, uint8_t allow)
+ {
+-    XSM_ASSERT_ACTION(XSM_HOOK);
++    XSM_ASSERT_ACTION(XSM_DM_PRIV);
+     return xsm_default_action(action, current->domain, d);
+ }
+ 
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index 12350834ed..c8c9ede7e1 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -680,6 +680,7 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+ 
+     /* These have individual XSM hooks and don't make it here. */
+     case XEN_DOMCTL_getdomaininfo:
++    case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_memory_mapping:
+         ASSERT_UNREACHABLE();
+         return -EILSEQ;
+@@ -698,7 +699,6 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+     /* These have individual XSM hooks (arch/x86/domctl.c) */
+     case XEN_DOMCTL_shadow_op:
+     case XEN_DOMCTL_ioport_permission:
+-    case XEN_DOMCTL_ioport_mapping:
+ #endif
+ #ifdef CONFIG_HAS_PASSTHROUGH
+     /*
+-- 
+2.53.0
+

--- a/SOURCES/0009-domctl-handle-XEN_DOMCTL_-un-bind_pt_irq-without-acq.patch
+++ b/SOURCES/0009-domctl-handle-XEN_DOMCTL_-un-bind_pt_irq-without-acq.patch
@@ -1,0 +1,154 @@
+From 814a193cdce1f76c0c017f00c51701c7ec88580a Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 09/18] domctl: handle XEN_DOMCTL_{,un}bind_pt_irq without
+ acquiring domctl lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+With dedicated locking added, the domctl lock isn't required here anymore.
+(It also already isn't used when pt_irq_{create,destroy}_bind() are
+invoked for PVH Dom0.) As the handling is in arch-specific code, no code
+is being moved, but the 2nd (extensible to other sub-ops like the ones
+here) invocation of arch_do_domctl() is being re-used.
+
+This is part of XSA-492.
+
+Fixes: fda49f9b3fbb ("Add build option to allow more hypercalls from stubdoms")
+Reported-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+Acked-by: Julien Grall <julien@xen.org>
+---
+ xen/arch/arm/domctl.c   | 4 ++--
+ xen/arch/x86/domctl.c   | 4 ++--
+ xen/common/domctl.c     | 2 ++
+ xen/include/xsm/dummy.h | 8 +++-----
+ xen/xsm/flask/hooks.c   | 5 ++---
+ 5 files changed, 11 insertions(+), 12 deletions(-)
+
+diff --git a/xen/arch/arm/domctl.c b/xen/arch/arm/domctl.c
+index 17ae157ff9..1a98f210eb 100644
+--- a/xen/arch/arm/domctl.c
++++ b/xen/arch/arm/domctl.c
+@@ -107,7 +107,7 @@ long arch_do_domctl(struct xen_domctl *domctl, struct domain *d,
+         if ( rc )
+             return rc;
+ 
+-        rc = xsm_bind_pt_irq(XSM_HOOK, d, bind);
++        rc = xsm_bind_pt_irq(XSM_DM_PRIV, d, bind);
+         if ( rc )
+             return rc;
+ 
+@@ -143,7 +143,7 @@ long arch_do_domctl(struct xen_domctl *domctl, struct domain *d,
+         if ( irq != virq )
+             return -EINVAL;
+ 
+-        rc = xsm_unbind_pt_irq(XSM_HOOK, d, bind);
++        rc = xsm_unbind_pt_irq(XSM_DM_PRIV, d, bind);
+         if ( rc )
+             return rc;
+ 
+diff --git a/xen/arch/x86/domctl.c b/xen/arch/x86/domctl.c
+index 94922dad21..3b0a4dca6e 100644
+--- a/xen/arch/x86/domctl.c
++++ b/xen/arch/x86/domctl.c
+@@ -554,7 +554,7 @@ long arch_do_domctl(
+         if ( !is_hvm_domain(d) )
+             break;
+ 
+-        ret = xsm_bind_pt_irq(XSM_HOOK, d, bind);
++        ret = xsm_bind_pt_irq(XSM_DM_PRIV, d, bind);
+         if ( ret )
+             break;
+ 
+@@ -592,7 +592,7 @@ long arch_do_domctl(
+         if ( !is_hvm_domain(d) )
+             break;
+ 
+-        ret = xsm_unbind_pt_irq(XSM_HOOK, d, bind);
++        ret = xsm_unbind_pt_irq(XSM_DM_PRIV, d, bind);
+         if ( ret )
+             break;
+ 
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index 051be67c69..8645add505 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -423,6 +423,8 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+     }
+ 
+     case XEN_DOMCTL_ioport_mapping:
++    case XEN_DOMCTL_bind_pt_irq:
++    case XEN_DOMCTL_unbind_pt_irq:
+         ret = arch_do_domctl(op, d, u_domctl);
+         goto domctl_out_unlock_domonly;
+ 
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index 68fdd2157f..3c4e62c800 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -168,12 +168,10 @@ static XSM_INLINE int cf_check xsm_domctl(
+     switch ( cmd )
+     {
+     case XEN_DOMCTL_bind_pt_irq:
+-    case XEN_DOMCTL_unbind_pt_irq:
+-        return xsm_default_action(XSM_DM_PRIV, current->domain, d);
+-
+     case XEN_DOMCTL_getdomaininfo:
+     case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_memory_mapping:
++    case XEN_DOMCTL_unbind_pt_irq:
+         ASSERT_UNREACHABLE();
+         return -EILSEQ;
+ 
+@@ -540,14 +538,14 @@ static XSM_INLINE int cf_check xsm_unmap_domain_pirq(
+ static XSM_INLINE int cf_check xsm_bind_pt_irq(
+     XSM_DEFAULT_ARG struct domain *d, struct xen_domctl_bind_pt_irq *bind)
+ {
+-    XSM_ASSERT_ACTION(XSM_HOOK);
++    XSM_ASSERT_ACTION(XSM_DM_PRIV);
+     return xsm_default_action(action, current->domain, d);
+ }
+ 
+ static XSM_INLINE int cf_check xsm_unbind_pt_irq(
+     XSM_DEFAULT_ARG struct domain *d, struct xen_domctl_bind_pt_irq *bind)
+ {
+-    XSM_ASSERT_ACTION(XSM_HOOK);
++    XSM_ASSERT_ACTION(XSM_DM_PRIV);
+     return xsm_default_action(action, current->domain, d);
+ }
+ 
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index c8c9ede7e1..c0411f192d 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -679,9 +679,11 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+         return avc_current_has_perm(ssidref, SECCLASS_DOMAIN, DOMAIN__CREATE, NULL);
+ 
+     /* These have individual XSM hooks and don't make it here. */
++    case XEN_DOMCTL_bind_pt_irq:
+     case XEN_DOMCTL_getdomaininfo:
+     case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_memory_mapping:
++    case XEN_DOMCTL_unbind_pt_irq:
+         ASSERT_UNREACHABLE();
+         return -EILSEQ;
+ 
+@@ -692,9 +694,6 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+     case XEN_DOMCTL_set_target:
+     case XEN_DOMCTL_vm_event_op:
+ 
+-    /* These have individual XSM hooks (arch/../domctl.c) */
+-    case XEN_DOMCTL_bind_pt_irq:
+-    case XEN_DOMCTL_unbind_pt_irq:
+ #ifdef CONFIG_X86
+     /* These have individual XSM hooks (arch/x86/domctl.c) */
+     case XEN_DOMCTL_shadow_op:
+-- 
+2.53.0
+

--- a/SOURCES/0010-domctl-handle-XEN_DOMCTL_io-mem-port-_permission-wit.patch
+++ b/SOURCES/0010-domctl-handle-XEN_DOMCTL_io-mem-port-_permission-wit.patch
@@ -1,0 +1,197 @@
+From bb9ca5746ef6d1b16e35089319df09031a24118b Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 10/18] domctl: handle XEN_DOMCTL_io{mem,port}_permission
+ without acquiring domctl lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+With dedicated locking added, the domctl lock isn't required here anymore.
+As the I/O port handling is in arch-specific code (x86 only), no code is
+being moved, but the 2nd invocation of arch_do_domctl() is re-used. Move
+the re-purposed dedicated XSM checks as early as possible.
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+---
+ xen/arch/x86/domctl.c   | 13 +++++++---
+ xen/common/domctl.c     | 54 ++++++++++++++++++++++-------------------
+ xen/include/xsm/dummy.h |  6 +++--
+ xen/xsm/flask/hooks.c   |  4 +--
+ 4 files changed, 44 insertions(+), 33 deletions(-)
+
+diff --git a/xen/arch/x86/domctl.c b/xen/arch/x86/domctl.c
+index 3b0a4dca6e..67b8db1074 100644
+--- a/xen/arch/x86/domctl.c
++++ b/xen/arch/x86/domctl.c
+@@ -249,12 +249,17 @@ long arch_do_domctl(
+         unsigned int np = domctl->u.ioport_permission.nr_ports;
+         int allow = domctl->u.ioport_permission.allow_access;
+ 
++        ret = -EINVAL;
++        if ( (fp + np) <= fp || (fp + np) > MAX_IOPORTS )
++            break;
++
++        ret = xsm_ioport_permission(XSM_PRIV, d, fp, fp + np - 1, allow);
++        if ( ret )
++            break;
++
+         iocaps_double_lock(d, true);
+ 
+-        if ( (fp + np) <= fp || (fp + np) > MAX_IOPORTS )
+-            ret = -EINVAL;
+-        else if ( !ioports_access_permitted(currd, fp, fp + np - 1) ||
+-                  xsm_ioport_permission(XSM_HOOK, d, fp, fp + np - 1, allow) )
++        if ( !ioports_access_permitted(currd, fp, fp + np - 1) )
+             ret = -EPERM;
+         else if ( allow )
+             ret = ioports_permit_access(d, fp, fp + np - 1);
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index 8645add505..1b8e32aeb1 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -362,6 +362,34 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         copyback = 1;
+         goto domctl_out_unlock_domonly;
+ 
++    case XEN_DOMCTL_iomem_permission:
++    {
++        unsigned long mfn = op->u.iomem_permission.first_mfn;
++        unsigned long nr_mfns = op->u.iomem_permission.nr_mfns;
++        bool allow = op->u.iomem_permission.allow_access;
++
++        ret = -EINVAL;
++        if ( (mfn + nr_mfns - 1) < mfn ) /* Wrap? */
++            goto domctl_out_unlock_domonly;
++
++        ret = xsm_iomem_permission(XSM_PRIV, d, mfn, mfn + nr_mfns - 1, allow);
++        if ( ret )
++            goto domctl_out_unlock_domonly;
++
++        iocaps_double_lock(d, true);
++
++        if ( !iomem_access_permitted(current->domain,
++                                     mfn, mfn + nr_mfns - 1) )
++            ret = -EPERM;
++        else if ( allow )
++            ret = iomem_permit_access(d, mfn, mfn + nr_mfns - 1);
++        else
++            ret = iomem_deny_access(d, mfn, mfn + nr_mfns - 1);
++
++        iocaps_double_unlock(d, true);
++        goto domctl_out_unlock_domonly;
++    }
++
+     case XEN_DOMCTL_memory_mapping:
+     {
+         unsigned long gfn = op->u.memory_mapping.first_gfn;
+@@ -422,6 +450,7 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         goto domctl_out_unlock_domonly;
+     }
+ 
++    case XEN_DOMCTL_ioport_permission:
+     case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_bind_pt_irq:
+     case XEN_DOMCTL_unbind_pt_irq:
+@@ -780,31 +809,6 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         break;
+     }
+ 
+-    case XEN_DOMCTL_iomem_permission:
+-    {
+-        unsigned long mfn = op->u.iomem_permission.first_mfn;
+-        unsigned long nr_mfns = op->u.iomem_permission.nr_mfns;
+-        int allow = op->u.iomem_permission.allow_access;
+-
+-        ret = -EINVAL;
+-        if ( (mfn + nr_mfns - 1) < mfn ) /* wrap? */
+-            break;
+-
+-        iocaps_double_lock(d, true);
+-
+-        if ( !iomem_access_permitted(current->domain,
+-                                     mfn, mfn + nr_mfns - 1) ||
+-             xsm_iomem_permission(XSM_HOOK, d, mfn, mfn + nr_mfns - 1, allow) )
+-            ret = -EPERM;
+-        else if ( allow )
+-            ret = iomem_permit_access(d, mfn, mfn + nr_mfns - 1);
+-        else
+-            ret = iomem_deny_access(d, mfn, mfn + nr_mfns - 1);
+-
+-        iocaps_double_unlock(d, true);
+-        break;
+-    }
+-
+     case XEN_DOMCTL_settimeoffset:
+         domain_set_time_offset(d, op->u.settimeoffset.time_offset_seconds);
+         break;
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index 3c4e62c800..53813542a4 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -169,7 +169,9 @@ static XSM_INLINE int cf_check xsm_domctl(
+     {
+     case XEN_DOMCTL_bind_pt_irq:
+     case XEN_DOMCTL_getdomaininfo:
++    case XEN_DOMCTL_iomem_permission:
+     case XEN_DOMCTL_ioport_mapping:
++    case XEN_DOMCTL_ioport_permission:
+     case XEN_DOMCTL_memory_mapping:
+     case XEN_DOMCTL_unbind_pt_irq:
+         ASSERT_UNREACHABLE();
+@@ -566,7 +568,7 @@ static XSM_INLINE int cf_check xsm_irq_permission(
+ static XSM_INLINE int cf_check xsm_iomem_permission(
+     XSM_DEFAULT_ARG struct domain *d, uint64_t s, uint64_t e, uint8_t allow)
+ {
+-    XSM_ASSERT_ACTION(XSM_HOOK);
++    XSM_ASSERT_ACTION(XSM_PRIV);
+     return xsm_default_action(action, current->domain, d);
+ }
+ 
+@@ -762,7 +764,7 @@ static XSM_INLINE int cf_check xsm_priv_mapping(
+ static XSM_INLINE int cf_check xsm_ioport_permission(
+     XSM_DEFAULT_ARG struct domain *d, uint32_t s, uint32_t e, uint8_t allow)
+ {
+-    XSM_ASSERT_ACTION(XSM_HOOK);
++    XSM_ASSERT_ACTION(XSM_PRIV);
+     return xsm_default_action(action, current->domain, d);
+ }
+ 
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index c0411f192d..421e3cf8a6 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -681,7 +681,9 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+     /* These have individual XSM hooks and don't make it here. */
+     case XEN_DOMCTL_bind_pt_irq:
+     case XEN_DOMCTL_getdomaininfo:
++    case XEN_DOMCTL_iomem_permission:
+     case XEN_DOMCTL_ioport_mapping:
++    case XEN_DOMCTL_ioport_permission:
+     case XEN_DOMCTL_memory_mapping:
+     case XEN_DOMCTL_unbind_pt_irq:
+         ASSERT_UNREACHABLE();
+@@ -690,14 +692,12 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+     /* These have individual XSM hooks (common/domctl.c) */
+     case XEN_DOMCTL_scheduler_op:
+     case XEN_DOMCTL_irq_permission:
+-    case XEN_DOMCTL_iomem_permission:
+     case XEN_DOMCTL_set_target:
+     case XEN_DOMCTL_vm_event_op:
+ 
+ #ifdef CONFIG_X86
+     /* These have individual XSM hooks (arch/x86/domctl.c) */
+     case XEN_DOMCTL_shadow_op:
+-    case XEN_DOMCTL_ioport_permission:
+ #endif
+ #ifdef CONFIG_HAS_PASSTHROUGH
+     /*
+-- 
+2.53.0
+

--- a/SOURCES/0011-domctl-handle-XEN_DOMCTL_irq_permission-without-acqu.patch
+++ b/SOURCES/0011-domctl-handle-XEN_DOMCTL_irq_permission-without-acqu.patch
@@ -1,0 +1,143 @@
+From 7dbce29a43e4f289fe7ee53a51c517d70591e553 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 11/18] domctl: handle XEN_DOMCTL_irq_permission without
+ acquiring domctl lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+With dedicated locking added, the domctl lock isn't required here anymore.
+Move the re-purposed (XSM_HOOK -> XSM_PRIV, as xsm_domctl() is now
+bypassed) dedicated XSM checks as early as possible.
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+---
+ xen/common/domctl.c     | 55 ++++++++++++++++++++++-------------------
+ xen/include/xsm/dummy.h |  3 ++-
+ xen/xsm/flask/hooks.c   |  2 +-
+ 3 files changed, 33 insertions(+), 27 deletions(-)
+
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index 1b8e32aeb1..871bf492b3 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -450,6 +450,36 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         goto domctl_out_unlock_domonly;
+     }
+ 
++    case XEN_DOMCTL_irq_permission:
++    {
++        unsigned int pirq = op->u.irq_permission.pirq, irq;
++        bool allow = op->u.irq_permission.allow_access;
++
++        ret = -EINVAL;
++        if ( pirq >= current->domain->nr_pirqs )
++            goto domctl_out_unlock_domonly;
++
++        irq = domain_pirq_to_irq(current->domain, pirq);
++
++        ret = -EPERM;
++        if ( irq )
++            ret = xsm_irq_permission(XSM_PRIV, d, irq, allow);
++        if ( ret )
++            goto domctl_out_unlock_domonly;
++
++        iocaps_double_lock(d, true);
++
++        if ( !irq_access_permitted(current->domain, irq) )
++            ret = -EPERM;
++        else if ( allow )
++            ret = irq_permit_access(d, irq);
++        else
++            ret = irq_deny_access(d, irq);
++
++        iocaps_double_unlock(d, true);
++        goto domctl_out_unlock_domonly;
++    }
++
+     case XEN_DOMCTL_ioport_permission:
+     case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_bind_pt_irq:
+@@ -784,31 +814,6 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         }
+         break;
+ 
+-    case XEN_DOMCTL_irq_permission:
+-    {
+-        unsigned int pirq = op->u.irq_permission.pirq, irq;
+-        int allow = op->u.irq_permission.allow_access;
+-
+-        if ( pirq >= current->domain->nr_pirqs )
+-        {
+-            ret = -EINVAL;
+-            break;
+-        }
+-
+-        iocaps_double_lock(d, true);
+-
+-        irq = pirq_access_permitted(current->domain, pirq);
+-        if ( !irq || xsm_irq_permission(XSM_HOOK, d, irq, allow) )
+-            ret = -EPERM;
+-        else if ( allow )
+-            ret = irq_permit_access(d, irq);
+-        else
+-            ret = irq_deny_access(d, irq);
+-
+-        iocaps_double_unlock(d, true);
+-        break;
+-    }
+-
+     case XEN_DOMCTL_settimeoffset:
+         domain_set_time_offset(d, op->u.settimeoffset.time_offset_seconds);
+         break;
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index 53813542a4..28c216424e 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -172,6 +172,7 @@ static XSM_INLINE int cf_check xsm_domctl(
+     case XEN_DOMCTL_iomem_permission:
+     case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_ioport_permission:
++    case XEN_DOMCTL_irq_permission:
+     case XEN_DOMCTL_memory_mapping:
+     case XEN_DOMCTL_unbind_pt_irq:
+         ASSERT_UNREACHABLE();
+@@ -561,7 +562,7 @@ static XSM_INLINE int cf_check xsm_unmap_domain_irq(
+ static XSM_INLINE int cf_check xsm_irq_permission(
+     XSM_DEFAULT_ARG struct domain *d, int pirq, uint8_t allow)
+ {
+-    XSM_ASSERT_ACTION(XSM_HOOK);
++    XSM_ASSERT_ACTION(XSM_PRIV);
+     return xsm_default_action(action, current->domain, d);
+ }
+ 
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index 421e3cf8a6..d1384c47df 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -684,6 +684,7 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+     case XEN_DOMCTL_iomem_permission:
+     case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_ioport_permission:
++    case XEN_DOMCTL_irq_permission:
+     case XEN_DOMCTL_memory_mapping:
+     case XEN_DOMCTL_unbind_pt_irq:
+         ASSERT_UNREACHABLE();
+@@ -691,7 +692,6 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+ 
+     /* These have individual XSM hooks (common/domctl.c) */
+     case XEN_DOMCTL_scheduler_op:
+-    case XEN_DOMCTL_irq_permission:
+     case XEN_DOMCTL_set_target:
+     case XEN_DOMCTL_vm_event_op:
+ 
+-- 
+2.53.0
+

--- a/SOURCES/0012-domctl-XSM-drop-vm_event_control-hook.patch
+++ b/SOURCES/0012-domctl-XSM-drop-vm_event_control-hook.patch
@@ -1,0 +1,215 @@
+From 15c278adfa30559f4a22fe19356ed01a2ba4be61 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 12/18] domctl/XSM: drop vm_event_control hook
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Integrate the checking with xsm_domctl(). Care needs to be taken with the
+GET_VERSION sub-op, which may be invoked with DOMID_INVALID, and which has
+been (and continues to be) bypassing XSM checking.
+
+Since the latter two parameters were unused, monitor_domctl() invoking the
+hook was actually redundant with the earlier xsm_domctl() (as can be seen
+nicely from the hunks changing xsm/flask/hooks.c).
+
+As a positive side effect, permissions are then checked at the same early
+point with and without Flask.
+
+While folding XEN_DOMCTL_monitor_op and XEN_DOMCTL_vm_event_op in
+flask_domctl(), also fold in XEN_DOMCTL_set_access_required.
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+
+Backport notes:
+Backported to xen 4.17.6-9.1 from RELEASE-4.17.6
+Conflicts in xen/include/xsm/dummy.h and xen/include/xsm/xsm.h due to
+5a0d9675e6 (add-pv-iommu-foreign-support.patch) which added
+xsm_iommu_control in context.
+
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+---
+ xen/common/domctl.c     | 17 +++++++++++++++++
+ xen/common/monitor.c    |  5 -----
+ xen/common/vm_event.c   |  4 ----
+ xen/include/xsm/dummy.h |  7 -------
+ xen/include/xsm/xsm.h   |  8 --------
+ xen/xsm/dummy.c         |  2 --
+ xen/xsm/flask/hooks.c   | 11 +----------
+ 7 files changed, 18 insertions(+), 36 deletions(-)
+
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index 871bf492b3..d0eeaf958d 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -480,6 +480,23 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         goto domctl_out_unlock_domonly;
+     }
+ 
++    case XEN_DOMCTL_vm_event_op:
++        if ( op->u.vm_event_op.op == XEN_VM_EVENT_GET_VERSION )
++        {
++            /* No XSM check (and potentially d == NULL) here. */
++            ret = vm_event_domctl(d, &op->u.vm_event_op);
++            if ( !ret )
++                copyback = true;
++            goto domctl_out_unlock_domonly;
++        }
++        if ( !d )
++        {
++            ret = -ESRCH;
++            goto domctl_out_unlock_domonly;
++        }
++        /* Other sub-ops handled further down. */
++        break;
++
+     case XEN_DOMCTL_ioport_permission:
+     case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_bind_pt_irq:
+diff --git a/xen/common/monitor.c b/xen/common/monitor.c
+index d5c9ff1cbf..aec6391faf 100644
+--- a/xen/common/monitor.c
++++ b/xen/common/monitor.c
+@@ -30,16 +30,11 @@
+ 
+ int monitor_domctl(struct domain *d, struct xen_domctl_monitor_op *mop)
+ {
+-    int rc;
+     bool requested_status = false;
+ 
+     if ( unlikely(current->domain == d) ) /* no domain_pause() */
+         return -EPERM;
+ 
+-    rc = xsm_vm_event_control(XSM_PRIV, d, mop->op, mop->event);
+-    if ( unlikely(rc) )
+-        return rc;
+-
+     switch ( mop->op )
+     {
+     case XEN_DOMCTL_MONITOR_OP_ENABLE:
+diff --git a/xen/common/vm_event.c b/xen/common/vm_event.c
+index ecf49c38a9..6af5f13f45 100644
+--- a/xen/common/vm_event.c
++++ b/xen/common/vm_event.c
+@@ -600,10 +600,6 @@ int vm_event_domctl(struct domain *d, struct xen_domctl_vm_event_op *vec)
+         return 0;
+     }
+ 
+-    rc = xsm_vm_event_control(XSM_PRIV, d, vec->mode, vec->op);
+-    if ( rc )
+-        return rc;
+-
+     if ( unlikely(d == current->domain) ) /* no domain_pause() */
+     {
+         gdprintk(XENLOG_INFO, "Tried to do a memory event op on itself.\n");
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index 28c216424e..4b098b3a7d 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -643,13 +643,6 @@ static XSM_INLINE int cf_check xsm_hvm_altp2mhvm_op(
+     }
+ }
+ 
+-static XSM_INLINE int cf_check xsm_vm_event_control(
+-    XSM_DEFAULT_ARG struct domain *d, int mode, int op)
+-{
+-    XSM_ASSERT_ACTION(XSM_PRIV);
+-    return xsm_default_action(action, current->domain, d);
+-}
+-
+ static XSM_INLINE int cf_check xsm_iommu_control(
+     XSM_DEFAULT_ARG struct domain *d, unsigned long op)
+ {
+diff --git a/xen/include/xsm/xsm.h b/xen/include/xsm/xsm.h
+index 3a2b02d4ba..30f6521d70 100644
+--- a/xen/include/xsm/xsm.h
++++ b/xen/include/xsm/xsm.h
+@@ -153,8 +153,6 @@ struct xsm_ops {
+     int (*hvm_altp2mhvm_op)(struct domain *d, uint64_t mode, uint32_t op);
+     int (*get_vnumainfo)(struct domain *d);
+ 
+-    int (*vm_event_control)(struct domain *d, int mode, int op);
+-
+ #ifdef CONFIG_MEM_ACCESS
+     int (*mem_access)(struct domain *d);
+ #endif
+@@ -627,12 +625,6 @@ static inline int xsm_get_vnumainfo(xsm_default_t def, struct domain *d)
+     return alternative_call(xsm_ops.get_vnumainfo, d);
+ }
+ 
+-static inline int xsm_vm_event_control(
+-    xsm_default_t def, struct domain *d, int mode, int op)
+-{
+-    return alternative_call(xsm_ops.vm_event_control, d, mode, op);
+-}
+-
+ static inline int xsm_iommu_control(xsm_default_t def, struct domain *d, unsigned long op)
+ {
+     return alternative_call(xsm_ops.iommu_control, d, op);
+diff --git a/xen/xsm/dummy.c b/xen/xsm/dummy.c
+index f7a6bbfd78..d4a1900c8f 100644
+--- a/xen/xsm/dummy.c
++++ b/xen/xsm/dummy.c
+@@ -110,8 +110,6 @@ static const struct xsm_ops __initconst_cf_clobber dummy_ops = {
+     .remove_from_physmap           = xsm_remove_from_physmap,
+     .map_gmfn_foreign              = xsm_map_gmfn_foreign,
+ 
+-    .vm_event_control              = xsm_vm_event_control,
+-
+ #ifdef CONFIG_MEM_ACCESS
+     .mem_access                    = xsm_mem_access,
+ #endif
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index d1384c47df..3895908487 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -693,7 +693,6 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+     /* These have individual XSM hooks (common/domctl.c) */
+     case XEN_DOMCTL_scheduler_op:
+     case XEN_DOMCTL_set_target:
+-    case XEN_DOMCTL_vm_event_op:
+ 
+ #ifdef CONFIG_X86
+     /* These have individual XSM hooks (arch/x86/domctl.c) */
+@@ -787,9 +786,8 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+         return current_has_perm(d, SECCLASS_DOMAIN, DOMAIN__TRIGGER);
+ 
+     case XEN_DOMCTL_set_access_required:
+-        return current_has_perm(d, SECCLASS_DOMAIN2, DOMAIN2__VM_EVENT);
+-
+     case XEN_DOMCTL_monitor_op:
++    case XEN_DOMCTL_vm_event_op:
+         return current_has_perm(d, SECCLASS_DOMAIN2, DOMAIN2__VM_EVENT);
+ 
+     case XEN_DOMCTL_debug_op:
+@@ -1349,11 +1347,6 @@ static int cf_check flask_hvm_altp2mhvm_op(struct domain *d, uint64_t mode, uint
+     return current_has_perm(d, SECCLASS_HVM, HVM__ALTP2MHVM_OP);
+ }
+ 
+-static int cf_check flask_vm_event_control(struct domain *d, int mode, int op)
+-{
+-    return current_has_perm(d, SECCLASS_DOMAIN2, DOMAIN2__VM_EVENT);
+-}
+-
+ #ifdef CONFIG_MEM_ACCESS
+ static int cf_check flask_mem_access(struct domain *d)
+ {
+@@ -1932,8 +1925,6 @@ static const struct xsm_ops __initconst_cf_clobber flask_ops = {
+     .do_xsm_op = do_flask_op,
+     .get_vnumainfo = flask_get_vnumainfo,
+ 
+-    .vm_event_control = flask_vm_event_control,
+-
+ #ifdef CONFIG_MEM_ACCESS
+     .mem_access = flask_mem_access,
+ #endif
+-- 
+2.53.0
+

--- a/SOURCES/0013-domctl-XSM-pass-full-struct-xen_domctl-to-xsm_domctl.patch
+++ b/SOURCES/0013-domctl-XSM-pass-full-struct-xen_domctl-to-xsm_domctl.patch
@@ -1,0 +1,132 @@
+From efece6b4e5c129f05978dafedc87f3d66333b9ae Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 13/18] domctl/XSM: pass full struct xen_domctl to xsm_domctl()
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Subsequently some sub-ops will want to inspect their sub-sub-ops. Plus
+this way we don't need to pass SSIDref separately anymore for
+domain_create.
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+---
+ xen/arch/x86/mm/paging.c |  2 +-
+ xen/common/domctl.c      |  4 +---
+ xen/include/xsm/dummy.h  |  4 ++--
+ xen/include/xsm/xsm.h    |  6 +++---
+ xen/xsm/flask/hooks.c    | 10 +++++-----
+ 5 files changed, 12 insertions(+), 14 deletions(-)
+
+diff --git a/xen/arch/x86/mm/paging.c b/xen/arch/x86/mm/paging.c
+index fad06f7347..7c14d0cc1d 100644
+--- a/xen/arch/x86/mm/paging.c
++++ b/xen/arch/x86/mm/paging.c
+@@ -778,7 +778,7 @@ long do_paging_domctl_cont(
+     if ( d == NULL )
+         return -ESRCH;
+ 
+-    ret = xsm_domctl(XSM_OTHER, d, op.cmd, 0 /* SSIDref not applicable */);
++    ret = xsm_domctl(XSM_OTHER, d, &op);
+     if ( !ret )
+     {
+         bool use_lock = arch_use_domctl_lock(&op);
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index d0eeaf958d..05541efd4e 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -509,9 +509,7 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         break;
+     }
+ 
+-    ret = xsm_domctl(XSM_OTHER, d, op->cmd,
+-                     /* SSIDRef only applicable for cmd == createdomain */
+-                     op->u.createdomain.ssidref);
++    ret = xsm_domctl(XSM_OTHER, d, op);
+     if ( ret )
+         goto domctl_out_unlock_domonly;
+ 
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index 4b098b3a7d..403d4d67f3 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -162,10 +162,10 @@ static XSM_INLINE int cf_check xsm_set_target(
+ }
+ 
+ static XSM_INLINE int cf_check xsm_domctl(
+-    XSM_DEFAULT_ARG struct domain *d, unsigned int cmd, uint32_t ssidref)
++    XSM_DEFAULT_ARG struct domain *d, struct xen_domctl *op)
+ {
+     XSM_ASSERT_ACTION(XSM_OTHER);
+-    switch ( cmd )
++    switch ( op->cmd )
+     {
+     case XEN_DOMCTL_bind_pt_irq:
+     case XEN_DOMCTL_getdomaininfo:
+diff --git a/xen/include/xsm/xsm.h b/xen/include/xsm/xsm.h
+index 30f6521d70..56d90b5231 100644
+--- a/xen/include/xsm/xsm.h
++++ b/xen/include/xsm/xsm.h
+@@ -60,7 +60,7 @@ struct xsm_ops {
+     int (*domctl_scheduler_op)(struct domain *d, int op);
+     int (*sysctl_scheduler_op)(int op);
+     int (*set_target)(struct domain *d, struct domain *e);
+-    int (*domctl)(struct domain *d, unsigned int cmd, uint32_t ssidref);
++    int (*domctl)(struct domain *d, struct xen_domctl *op);
+     int (*sysctl)(int cmd);
+     int (*readconsole)(uint32_t clear);
+ 
+@@ -248,9 +248,9 @@ static inline int xsm_set_target(
+ }
+ 
+ static inline int xsm_domctl(xsm_default_t def, struct domain *d,
+-                             unsigned int cmd, uint32_t ssidref)
++                             struct xen_domctl *op)
+ {
+-    return alternative_call(xsm_ops.domctl, d, cmd, ssidref);
++    return alternative_call(xsm_ops.domctl, d, op);
+ }
+ 
+ static inline int xsm_sysctl(xsm_default_t def, int cmd)
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index 3895908487..425698bb57 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -663,10 +663,9 @@ static int cf_check flask_set_target(struct domain *d, struct domain *t)
+     return rc;
+ }
+ 
+-static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+-                                 uint32_t ssidref)
++static int cf_check flask_domctl(struct domain *d, struct xen_domctl *op)
+ {
+-    switch ( cmd )
++    switch ( op->cmd )
+     {
+     case XEN_DOMCTL_createdomain:
+         /*
+@@ -676,7 +675,8 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+          * Note that d is NULL because we haven't even allocated memory for it
+          * this early in XEN_DOMCTL_createdomain.
+          */
+-        return avc_current_has_perm(ssidref, SECCLASS_DOMAIN, DOMAIN__CREATE, NULL);
++        return avc_current_has_perm(op->u.createdomain.ssidref, SECCLASS_DOMAIN,
++                                    DOMAIN__CREATE, NULL);
+ 
+     /* These have individual XSM hooks and don't make it here. */
+     case XEN_DOMCTL_bind_pt_irq:
+@@ -843,7 +843,7 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
+         return current_has_perm(d, SECCLASS_DOMAIN2, DOMAIN2__GET_RUNSTATE_INFO);
+ 
+     default:
+-        return avc_unknown_permission("domctl", cmd);
++        return avc_unknown_permission("domctl", op->cmd);
+     }
+ }
+ 
+-- 
+2.53.0
+

--- a/SOURCES/0014-domctl-XSM-drop-scheduler_op-hook.patch
+++ b/SOURCES/0014-domctl-XSM-drop-scheduler_op-hook.patch
@@ -1,0 +1,136 @@
+From 361d72b0424f50b4df4ae661cb0b80b4f18d7f17 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 14/18] domctl/XSM: drop scheduler_op hook
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Integrate the checking with xsm_domctl(), now that it has the full op
+struct passed. As a positive side effect, permissions are then checked at
+the same early point with and without Flask.
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+Reviewed-by: Juergen Gross <jgross@suse.com>
+---
+ xen/common/sched/core.c | 4 ----
+ xen/include/xsm/dummy.h | 7 -------
+ xen/include/xsm/xsm.h   | 7 -------
+ xen/xsm/dummy.c         | 1 -
+ xen/xsm/flask/hooks.c   | 7 ++++---
+ 5 files changed, 4 insertions(+), 22 deletions(-)
+
+diff --git a/xen/common/sched/core.c b/xen/common/sched/core.c
+index 716bf01caa..a051ac22e2 100644
+--- a/xen/common/sched/core.c
++++ b/xen/common/sched/core.c
+@@ -2212,10 +2212,6 @@ long sched_adjust(struct domain *d, struct xen_domctl_scheduler_op *op)
+ {
+     long ret;
+ 
+-    ret = xsm_domctl_scheduler_op(XSM_HOOK, d, op->cmd);
+-    if ( ret )
+-        return ret;
+-
+     if ( op->sched_id != dom_scheduler(d)->sched_id )
+         return -EINVAL;
+ 
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index 403d4d67f3..699037fb6c 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -141,13 +141,6 @@ static XSM_INLINE int cf_check xsm_getdomaininfo(
+     return xsm_default_action(action, current->domain, d);
+ }
+ 
+-static XSM_INLINE int cf_check xsm_domctl_scheduler_op(
+-    XSM_DEFAULT_ARG struct domain *d, int cmd)
+-{
+-    XSM_ASSERT_ACTION(XSM_HOOK);
+-    return xsm_default_action(action, current->domain, d);
+-}
+-
+ static XSM_INLINE int cf_check xsm_sysctl_scheduler_op(XSM_DEFAULT_ARG int cmd)
+ {
+     XSM_ASSERT_ACTION(XSM_HOOK);
+diff --git a/xen/include/xsm/xsm.h b/xen/include/xsm/xsm.h
+index 56d90b5231..f45509c043 100644
+--- a/xen/include/xsm/xsm.h
++++ b/xen/include/xsm/xsm.h
+@@ -57,7 +57,6 @@ struct xsm_ops {
+                                 struct xen_domctl_getdomaininfo *info);
+     int (*domain_create)(struct domain *d, uint32_t ssidref);
+     int (*getdomaininfo)(struct domain *d);
+-    int (*domctl_scheduler_op)(struct domain *d, int op);
+     int (*sysctl_scheduler_op)(int op);
+     int (*set_target)(struct domain *d, struct domain *e);
+     int (*domctl)(struct domain *d, struct xen_domctl *op);
+@@ -230,12 +229,6 @@ static inline int xsm_getdomaininfo(xsm_default_t def, struct domain *d)
+     return alternative_call(xsm_ops.getdomaininfo, d);
+ }
+ 
+-static inline int xsm_domctl_scheduler_op(
+-    xsm_default_t def, struct domain *d, int cmd)
+-{
+-    return alternative_call(xsm_ops.domctl_scheduler_op, d, cmd);
+-}
+-
+ static inline int xsm_sysctl_scheduler_op(xsm_default_t def, int cmd)
+ {
+     return alternative_call(xsm_ops.sysctl_scheduler_op, cmd);
+diff --git a/xen/xsm/dummy.c b/xen/xsm/dummy.c
+index d4a1900c8f..378f2281ca 100644
+--- a/xen/xsm/dummy.c
++++ b/xen/xsm/dummy.c
+@@ -18,7 +18,6 @@ static const struct xsm_ops __initconst_cf_clobber dummy_ops = {
+     .security_domaininfo           = xsm_security_domaininfo,
+     .domain_create                 = xsm_domain_create,
+     .getdomaininfo                 = xsm_getdomaininfo,
+-    .domctl_scheduler_op           = xsm_domctl_scheduler_op,
+     .sysctl_scheduler_op           = xsm_sysctl_scheduler_op,
+     .set_target                    = xsm_set_target,
+     .domctl                        = xsm_domctl,
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index 425698bb57..c00bfd78c5 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -607,7 +607,7 @@ static int cf_check flask_getdomaininfo(struct domain *d)
+     return current_has_perm(d, SECCLASS_DOMAIN, DOMAIN__GETDOMAININFO);
+ }
+ 
+-static int cf_check flask_domctl_scheduler_op(struct domain *d, int op)
++static int flask_domctl_scheduler_op(struct domain *d, int op)
+ {
+     switch ( op )
+     {
+@@ -691,7 +691,6 @@ static int cf_check flask_domctl(struct domain *d, struct xen_domctl *op)
+         return -EILSEQ;
+ 
+     /* These have individual XSM hooks (common/domctl.c) */
+-    case XEN_DOMCTL_scheduler_op:
+     case XEN_DOMCTL_set_target:
+ 
+ #ifdef CONFIG_X86
+@@ -739,6 +738,9 @@ static int cf_check flask_domctl(struct domain *d, struct xen_domctl *op)
+     case XEN_DOMCTL_setdomainhandle:
+         return current_has_perm(d, SECCLASS_DOMAIN, DOMAIN__SETDOMAINHANDLE);
+ 
++    case XEN_DOMCTL_scheduler_op:
++        return flask_domctl_scheduler_op(d, op->u.scheduler_op.cmd);
++
+     case XEN_DOMCTL_set_ext_vcpucontext:
+     case XEN_DOMCTL_set_vcpu_msrs:
+     case XEN_DOMCTL_setvcpucontext:
+@@ -1852,7 +1854,6 @@ static const struct xsm_ops __initconst_cf_clobber flask_ops = {
+     .security_domaininfo = flask_security_domaininfo,
+     .domain_create = flask_domain_create,
+     .getdomaininfo = flask_getdomaininfo,
+-    .domctl_scheduler_op = flask_domctl_scheduler_op,
+     .sysctl_scheduler_op = flask_sysctl_scheduler_op,
+     .set_target = flask_set_target,
+     .domctl = flask_domctl,
+-- 
+2.53.0
+

--- a/SOURCES/0015-domctl-XSM-drop-shadow_control_op-hook.patch
+++ b/SOURCES/0015-domctl-XSM-drop-shadow_control_op-hook.patch
@@ -1,0 +1,148 @@
+From 2e8675e3f80edca4aa504eebaa64c6a01c69a1cf Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 15/18] domctl/XSM: drop shadow_control_op hook
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Integrate the checking with xsm_domctl(), now that it has the full op
+struct passed. As a positive side effect, permissions are then checked at
+the same early point with and without Flask.
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+---
+ xen/arch/x86/mm/paging.c |  4 ----
+ xen/include/xsm/dummy.h  |  7 -------
+ xen/include/xsm/xsm.h    |  7 -------
+ xen/xsm/dummy.c          |  1 -
+ xen/xsm/flask/hooks.c    | 13 +++++++------
+ 5 files changed, 7 insertions(+), 25 deletions(-)
+
+diff --git a/xen/arch/x86/mm/paging.c b/xen/arch/x86/mm/paging.c
+index 7c14d0cc1d..6f305ed277 100644
+--- a/xen/arch/x86/mm/paging.c
++++ b/xen/arch/x86/mm/paging.c
+@@ -720,10 +720,6 @@ int paging_domctl(struct domain *d, struct xen_domctl_shadow_op *sc,
+         return -EBUSY;
+     }
+ 
+-    rc = xsm_shadow_control(XSM_HOOK, d, sc->op);
+-    if ( rc )
+-        return rc;
+-
+     /* Code to handle log-dirty. Note that some log dirty operations
+      * piggy-back on shadow operations. For example, when
+      * XEN_DOMCTL_SHADOW_OP_OFF is called, it first checks whether log dirty
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index 699037fb6c..d6e2c602d6 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -680,13 +680,6 @@ static XSM_INLINE int cf_check xsm_do_mca(XSM_DEFAULT_VOID)
+     return xsm_default_action(action, current->domain, NULL);
+ }
+ 
+-static XSM_INLINE int cf_check xsm_shadow_control(
+-    XSM_DEFAULT_ARG struct domain *d, uint32_t op)
+-{
+-    XSM_ASSERT_ACTION(XSM_HOOK);
+-    return xsm_default_action(action, current->domain, d);
+-}
+-
+ static XSM_INLINE int cf_check xsm_mem_sharing_op(
+     XSM_DEFAULT_ARG struct domain *d, struct domain *cd, int op)
+ {
+diff --git a/xen/include/xsm/xsm.h b/xen/include/xsm/xsm.h
+index f45509c043..abb58dfd75 100644
+--- a/xen/include/xsm/xsm.h
++++ b/xen/include/xsm/xsm.h
+@@ -168,7 +168,6 @@ struct xsm_ops {
+ 
+ #ifdef CONFIG_X86
+     int (*do_mca)(void);
+-    int (*shadow_control)(struct domain *d, uint32_t op);
+     int (*mem_sharing_op)(struct domain *d, struct domain *cd, int op);
+     int (*apic)(struct domain *d, int cmd);
+     int (*machine_memory_map)(void);
+@@ -655,12 +654,6 @@ static inline int xsm_do_mca(xsm_default_t def)
+     return alternative_call(xsm_ops.do_mca);
+ }
+ 
+-static inline int xsm_shadow_control(
+-    xsm_default_t def, struct domain *d, uint32_t op)
+-{
+-    return alternative_call(xsm_ops.shadow_control, d, op);
+-}
+-
+ static inline int xsm_mem_sharing_op(
+     xsm_default_t def, struct domain *d, struct domain *cd, int op)
+ {
+diff --git a/xen/xsm/dummy.c b/xen/xsm/dummy.c
+index 378f2281ca..15dac873b3 100644
+--- a/xen/xsm/dummy.c
++++ b/xen/xsm/dummy.c
+@@ -124,7 +124,6 @@ static const struct xsm_ops __initconst_cf_clobber dummy_ops = {
+     .platform_op                   = xsm_platform_op,
+ #ifdef CONFIG_X86
+     .do_mca                        = xsm_do_mca,
+-    .shadow_control                = xsm_shadow_control,
+     .mem_sharing_op                = xsm_mem_sharing_op,
+     .apic                          = xsm_apic,
+     .machine_memory_map            = xsm_machine_memory_map,
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index c00bfd78c5..af4be547f6 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -40,6 +40,7 @@
+ 
+ #ifdef CONFIG_X86
+ #include <asm/pv/shim.h>
++static int flask_shadow_control(struct domain *d, unsigned int op);
+ #else
+ #define pv_shim false
+ #endif
+@@ -693,10 +694,6 @@ static int cf_check flask_domctl(struct domain *d, struct xen_domctl *op)
+     /* These have individual XSM hooks (common/domctl.c) */
+     case XEN_DOMCTL_set_target:
+ 
+-#ifdef CONFIG_X86
+-    /* These have individual XSM hooks (arch/x86/domctl.c) */
+-    case XEN_DOMCTL_shadow_op:
+-#endif
+ #ifdef CONFIG_HAS_PASSTHROUGH
+     /*
+      * These have individual XSM hooks
+@@ -781,6 +778,11 @@ static int cf_check flask_domctl(struct domain *d, struct xen_domctl *op)
+     case XEN_DOMCTL_get_address_size:
+         return current_has_perm(d, SECCLASS_DOMAIN, DOMAIN__GETADDRSIZE);
+ 
++#ifdef CONFIG_X86
++    case XEN_DOMCTL_shadow_op:
++        return flask_shadow_control(d, op->u.shadow_op.op);
++#endif
++
+     case XEN_DOMCTL_mem_sharing_op:
+         return current_has_perm(d, SECCLASS_HVM, HVM__MEM_SHARING);
+ 
+@@ -1580,7 +1582,7 @@ static int cf_check flask_do_mca(void)
+     return domain_has_xen(current->domain, XEN__MCA_OP);
+ }
+ 
+-static int cf_check flask_shadow_control(struct domain *d, uint32_t op)
++static int flask_shadow_control(struct domain *d, unsigned int op)
+ {
+     uint32_t perm;
+ 
+@@ -1960,7 +1962,6 @@ static const struct xsm_ops __initconst_cf_clobber flask_ops = {
+     .platform_op = flask_platform_op,
+ #ifdef CONFIG_X86
+     .do_mca = flask_do_mca,
+-    .shadow_control = flask_shadow_control,
+     .mem_sharing_op = flask_mem_sharing_op,
+     .apic = flask_apic,
+     .machine_memory_map = flask_machine_memory_map,
+-- 
+2.53.0
+

--- a/SOURCES/0016-domctl-handle-XEN_DOMCTL_get_device_group-without-ac.patch
+++ b/SOURCES/0016-domctl-handle-XEN_DOMCTL_get_device_group-without-ac.patch
@@ -1,0 +1,119 @@
+From 91dafa700ce3c719822ef46c23a1a786ccade8b6 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 16/18] domctl: handle XEN_DOMCTL_get_device_group without
+ acquiring domctl lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+iommu_get_device_group() uses its own locking. Thus, with caller side
+locking irrelevant, it can as well be called with the domctl lock not
+held.
+
+Move the handling not only ahead of acquiring the lock, but also ahead
+of the XSM check, leveraging that the sub-op has its own hook.
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+---
+ xen/common/domctl.c           | 5 ++++-
+ xen/drivers/passthrough/pci.c | 4 ++--
+ xen/include/xsm/dummy.h       | 3 ++-
+ xen/xsm/flask/hooks.c         | 2 +-
+ 4 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index 05541efd4e..588c22feed 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -497,6 +497,10 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         /* Other sub-ops handled further down. */
+         break;
+ 
++    case XEN_DOMCTL_get_device_group:
++        ret = iommu_do_domctl(op, d, u_domctl);
++        goto domctl_out_unlock_domonly;
++
+     case XEN_DOMCTL_ioport_permission:
+     case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_bind_pt_irq:
+@@ -920,7 +924,6 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+     case XEN_DOMCTL_assign_device:
+     case XEN_DOMCTL_test_assign_device:
+     case XEN_DOMCTL_deassign_device:
+-    case XEN_DOMCTL_get_device_group:
+         ret = iommu_do_domctl(op, d, u_domctl);
+         break;
+ 
+diff --git a/xen/drivers/passthrough/pci.c b/xen/drivers/passthrough/pci.c
+index ce450dc0ba..9dd6fcabe5 100644
+--- a/xen/drivers/passthrough/pci.c
++++ b/xen/drivers/passthrough/pci.c
+@@ -1579,7 +1579,7 @@ static int iommu_get_device_group(
+         if ( (pdev->seg != seg) || ((b == bus) && (df == devfn)) )
+             continue;
+ 
+-        if ( xsm_get_device_group(XSM_HOOK, (seg << 16) | (b << 8) | df) )
++        if ( xsm_get_device_group(XSM_PRIV, (seg << 16) | (b << 8) | df) )
+             continue;
+ 
+         sdev_id = iommu_call(ops, get_device_group_id, seg, b, df);
+@@ -1649,7 +1649,7 @@ int iommu_do_pci_domctl(
+         u32 max_sdevs;
+         XEN_GUEST_HANDLE_64(uint32) sdevs;
+ 
+-        ret = xsm_get_device_group(XSM_HOOK, domctl->u.get_device_group.machine_sbdf);
++        ret = xsm_get_device_group(XSM_PRIV, domctl->u.get_device_group.machine_sbdf);
+         if ( ret )
+             break;
+ 
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index d6e2c602d6..b8488b74ff 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -162,6 +162,7 @@ static XSM_INLINE int cf_check xsm_domctl(
+     {
+     case XEN_DOMCTL_bind_pt_irq:
+     case XEN_DOMCTL_getdomaininfo:
++    case XEN_DOMCTL_get_device_group:
+     case XEN_DOMCTL_iomem_permission:
+     case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_ioport_permission:
+@@ -399,7 +400,7 @@ static XSM_INLINE int cf_check xsm_get_vnumainfo(
+ static XSM_INLINE int cf_check xsm_get_device_group(
+     XSM_DEFAULT_ARG uint32_t machine_bdf)
+ {
+-    XSM_ASSERT_ACTION(XSM_HOOK);
++    XSM_ASSERT_ACTION(XSM_PRIV);
+     return xsm_default_action(action, current->domain, NULL);
+ }
+ 
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index af4be547f6..b8a0ff5581 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -682,6 +682,7 @@ static int cf_check flask_domctl(struct domain *d, struct xen_domctl *op)
+     /* These have individual XSM hooks and don't make it here. */
+     case XEN_DOMCTL_bind_pt_irq:
+     case XEN_DOMCTL_getdomaininfo:
++    case XEN_DOMCTL_get_device_group:
+     case XEN_DOMCTL_iomem_permission:
+     case XEN_DOMCTL_ioport_mapping:
+     case XEN_DOMCTL_ioport_permission:
+@@ -699,7 +700,6 @@ static int cf_check flask_domctl(struct domain *d, struct xen_domctl *op)
+      * These have individual XSM hooks
+      * (drivers/passthrough/{pci,device_tree.c)
+      */
+-    case XEN_DOMCTL_get_device_group:
+     case XEN_DOMCTL_test_assign_device:
+     case XEN_DOMCTL_assign_device:
+     case XEN_DOMCTL_deassign_device:
+-- 
+2.53.0
+

--- a/SOURCES/0017-domctl-XSM-drop-de-assign_-dt-device-hooks.patch
+++ b/SOURCES/0017-domctl-XSM-drop-de-assign_-dt-device-hooks.patch
@@ -1,0 +1,414 @@
+From c9cb6f6eabdc533c521e14f7f1e5476934047881 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 17/18] domctl/XSM: drop {,de}assign_{,dt}device hooks
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Integrate the checking with xsm_domctl(). As a positive side effect,
+permissions are then checked at the same early point with and without
+Flask. As the DT device path needs fetching earlier (but must not be
+double fetched), cache it in a private field of the public interface
+struct.
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+---
+ xen/common/domctl.c                   |  9 +++
+ xen/drivers/passthrough/device_tree.c | 36 ++++++------
+ xen/drivers/passthrough/pci.c         |  8 ---
+ xen/include/public/domctl.h           |  5 +-
+ xen/include/xsm/dummy.h               | 32 -----------
+ xen/include/xsm/xsm.h                 | 34 ------------
+ xen/xsm/dummy.c                       |  7 ---
+ xen/xsm/flask/hooks.c                 | 79 ++++++++++++++++++++-------
+ 8 files changed, 89 insertions(+), 121 deletions(-)
+
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index 588c22feed..bf97dc8a36 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -327,6 +327,10 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+     case XEN_DOMCTL_deassign_device:
+         if ( op->domain == DOMID_IO )
+         {
++#ifdef CONFIG_HAS_DEVICE_TREE
++            if ( op->u.assign_device.dev == XEN_DOMCTL_DEV_DT )
++                op->u.assign_device.u.dt.dev = NULL;
++#endif
+             d = dom_io;
+             break;
+         }
+@@ -334,6 +338,11 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+             return -ESRCH;
+         /* fall through */
+     case XEN_DOMCTL_test_assign_device:
++#ifdef CONFIG_HAS_DEVICE_TREE
++        if ( op->u.assign_device.dev == XEN_DOMCTL_DEV_DT )
++            op->u.assign_device.u.dt.dev = NULL;
++        fallthrough;
++#endif
+     case XEN_DOMCTL_vm_event_op:
+         if ( op->domain == DOMID_INVALID )
+         {
+diff --git a/xen/drivers/passthrough/device_tree.c b/xen/drivers/passthrough/device_tree.c
+index 1c32d7b50c..acfda2c8c6 100644
+--- a/xen/drivers/passthrough/device_tree.c
++++ b/xen/drivers/passthrough/device_tree.c
+@@ -213,15 +213,15 @@ int iommu_do_dt_domctl(struct xen_domctl *domctl, struct domain *d,
+         if ( (d && d->is_dying) || domctl->u.assign_device.flags )
+             break;
+ 
+-        ret = dt_find_node_by_gpath(domctl->u.assign_device.u.dt.path,
+-                                    domctl->u.assign_device.u.dt.size,
+-                                    &dev);
+-        if ( ret )
+-            break;
+-
+-        ret = xsm_assign_dtdevice(XSM_HOOK, d, dt_node_full_name(dev));
+-        if ( ret )
+-            break;
++        dev = domctl->u.assign_device.u.dt.dev;
++        if ( !dev )
++        {
++            ret = dt_find_node_by_gpath(domctl->u.assign_device.u.dt.path,
++                                        domctl->u.assign_device.u.dt.size,
++                                        &dev);
++            if ( ret )
++                break;
++        }
+ 
+         if ( domctl->cmd == XEN_DOMCTL_test_assign_device )
+         {
+@@ -262,15 +262,15 @@ int iommu_do_dt_domctl(struct xen_domctl *domctl, struct domain *d,
+         if ( domctl->u.assign_device.flags )
+             break;
+ 
+-        ret = dt_find_node_by_gpath(domctl->u.assign_device.u.dt.path,
+-                                    domctl->u.assign_device.u.dt.size,
+-                                    &dev);
+-        if ( ret )
+-            break;
+-
+-        ret = xsm_deassign_dtdevice(XSM_HOOK, d, dt_node_full_name(dev));
+-        if ( ret )
+-            break;
++        dev = domctl->u.assign_device.u.dt.dev;
++        if ( !dev )
++        {
++            ret = dt_find_node_by_gpath(domctl->u.assign_device.u.dt.path,
++                                        domctl->u.assign_device.u.dt.size,
++                                        &dev);
++            if ( ret )
++                break;
++        }
+ 
+         if ( d == dom_io )
+             return -EINVAL;
+diff --git a/xen/drivers/passthrough/pci.c b/xen/drivers/passthrough/pci.c
+index 9dd6fcabe5..b7e6cd4dcf 100644
+--- a/xen/drivers/passthrough/pci.c
++++ b/xen/drivers/passthrough/pci.c
+@@ -1699,10 +1699,6 @@ int iommu_do_pci_domctl(
+ 
+         machine_sbdf = domctl->u.assign_device.u.pci.machine_sbdf;
+ 
+-        ret = xsm_assign_device(XSM_HOOK, d, machine_sbdf);
+-        if ( ret )
+-            break;
+-
+         seg = machine_sbdf >> 16;
+         bus = PCI_BUS(machine_sbdf);
+         devfn = PCI_DEVFN(machine_sbdf);
+@@ -1744,10 +1740,6 @@ int iommu_do_pci_domctl(
+ 
+         machine_sbdf = domctl->u.assign_device.u.pci.machine_sbdf;
+ 
+-        ret = xsm_deassign_device(XSM_HOOK, d, machine_sbdf);
+-        if ( ret )
+-            break;
+-
+         seg = machine_sbdf >> 16;
+         bus = PCI_BUS(machine_sbdf);
+         devfn = PCI_DEVFN(machine_sbdf);
+diff --git a/xen/include/public/domctl.h b/xen/include/public/domctl.h
+index eb1d3f7f81..e9022dd329 100644
+--- a/xen/include/public/domctl.h
++++ b/xen/include/public/domctl.h
+@@ -531,7 +531,10 @@ struct xen_domctl_assign_device {
+         } pci;
+         struct {
+             uint32_t size; /* Length of the path */
+-            XEN_GUEST_HANDLE_64(char) path; /* path to the device tree node */
++            XEN_GUEST_HANDLE_64(char) path; /* Path to the device tree node */
++#ifdef __XEN__
++            struct dt_device_node *dev; /* Resolved device node of the above */
++#endif
+         } dt;
+     } u;
+ };
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index b8488b74ff..dfc4dec46a 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -403,40 +403,8 @@ static XSM_INLINE int cf_check xsm_get_device_group(
+     XSM_ASSERT_ACTION(XSM_PRIV);
+     return xsm_default_action(action, current->domain, NULL);
+ }
+-
+-static XSM_INLINE int cf_check xsm_assign_device(
+-    XSM_DEFAULT_ARG struct domain *d, uint32_t machine_bdf)
+-{
+-    XSM_ASSERT_ACTION(XSM_HOOK);
+-    return xsm_default_action(action, current->domain, d);
+-}
+-
+-static XSM_INLINE int cf_check xsm_deassign_device(
+-    XSM_DEFAULT_ARG struct domain *d, uint32_t machine_bdf)
+-{
+-    XSM_ASSERT_ACTION(XSM_HOOK);
+-    return xsm_default_action(action, current->domain, d);
+-}
+-
+ #endif /* HAS_PASSTHROUGH && HAS_PCI */
+ 
+-#if defined(CONFIG_HAS_PASSTHROUGH) && defined(CONFIG_HAS_DEVICE_TREE)
+-static XSM_INLINE int cf_check xsm_assign_dtdevice(
+-    XSM_DEFAULT_ARG struct domain *d, const char *dtpath)
+-{
+-    XSM_ASSERT_ACTION(XSM_HOOK);
+-    return xsm_default_action(action, current->domain, d);
+-}
+-
+-static XSM_INLINE int cf_check xsm_deassign_dtdevice(
+-    XSM_DEFAULT_ARG struct domain *d, const char *dtpath)
+-{
+-    XSM_ASSERT_ACTION(XSM_HOOK);
+-    return xsm_default_action(action, current->domain, d);
+-}
+-
+-#endif /* HAS_PASSTHROUGH && HAS_DEVICE_TREE */
+-
+ static XSM_INLINE int cf_check xsm_resource_plug_core(XSM_DEFAULT_VOID)
+ {
+     XSM_ASSERT_ACTION(XSM_HOOK);
+diff --git a/xen/include/xsm/xsm.h b/xen/include/xsm/xsm.h
+index abb58dfd75..b072285b06 100644
+--- a/xen/include/xsm/xsm.h
++++ b/xen/include/xsm/xsm.h
+@@ -122,13 +122,6 @@ struct xsm_ops {
+ 
+ #if defined(CONFIG_HAS_PASSTHROUGH) && defined(CONFIG_HAS_PCI)
+     int (*get_device_group)(uint32_t machine_bdf);
+-    int (*assign_device)(struct domain *d, uint32_t machine_bdf);
+-    int (*deassign_device)(struct domain *d, uint32_t machine_bdf);
+-#endif
+-
+-#if defined(CONFIG_HAS_PASSTHROUGH) && defined(CONFIG_HAS_DEVICE_TREE)
+-    int (*assign_dtdevice)(struct domain *d, const char *dtpath);
+-    int (*deassign_dtdevice)(struct domain *d, const char *dtpath);
+ #endif
+ 
+     int (*resource_plug_core)(void);
+@@ -507,35 +500,8 @@ static inline int xsm_get_device_group(xsm_default_t def, uint32_t machine_bdf)
+ {
+     return alternative_call(xsm_ops.get_device_group, machine_bdf);
+ }
+-
+-static inline int xsm_assign_device(
+-    xsm_default_t def, struct domain *d, uint32_t machine_bdf)
+-{
+-    return alternative_call(xsm_ops.assign_device, d, machine_bdf);
+-}
+-
+-static inline int xsm_deassign_device(
+-    xsm_default_t def, struct domain *d, uint32_t machine_bdf)
+-{
+-    return alternative_call(xsm_ops.deassign_device, d, machine_bdf);
+-}
+ #endif /* HAS_PASSTHROUGH && HAS_PCI) */
+ 
+-#if defined(CONFIG_HAS_PASSTHROUGH) && defined(CONFIG_HAS_DEVICE_TREE)
+-static inline int xsm_assign_dtdevice(
+-    xsm_default_t def, struct domain *d, const char *dtpath)
+-{
+-    return alternative_call(xsm_ops.assign_dtdevice, d, dtpath);
+-}
+-
+-static inline int xsm_deassign_dtdevice(
+-    xsm_default_t def, struct domain *d, const char *dtpath)
+-{
+-    return alternative_call(xsm_ops.deassign_dtdevice, d, dtpath);
+-}
+-
+-#endif /* HAS_PASSTHROUGH && HAS_DEVICE_TREE */
+-
+ static inline int xsm_resource_plug_pci(xsm_default_t def, uint32_t machine_bdf)
+ {
+     return alternative_call(xsm_ops.resource_plug_pci, machine_bdf);
+diff --git a/xen/xsm/dummy.c b/xen/xsm/dummy.c
+index 15dac873b3..cae682cf22 100644
+--- a/xen/xsm/dummy.c
++++ b/xen/xsm/dummy.c
+@@ -76,13 +76,6 @@ static const struct xsm_ops __initconst_cf_clobber dummy_ops = {
+ 
+ #if defined(CONFIG_HAS_PASSTHROUGH) && defined(CONFIG_HAS_PCI)
+     .get_device_group              = xsm_get_device_group,
+-    .assign_device                 = xsm_assign_device,
+-    .deassign_device               = xsm_deassign_device,
+-#endif
+-
+-#if defined(CONFIG_HAS_PASSTHROUGH) && defined(CONFIG_HAS_DEVICE_TREE)
+-    .assign_dtdevice               = xsm_assign_dtdevice,
+-    .deassign_dtdevice             = xsm_deassign_dtdevice,
+ #endif
+ 
+     .resource_plug_core            = xsm_resource_plug_core,
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index b8a0ff5581..579e977284 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -45,6 +45,17 @@ static int flask_shadow_control(struct domain *d, unsigned int op);
+ #define pv_shim false
+ #endif
+ 
++#ifdef CONFIG_HAS_PASSTHROUGH
++#ifdef CONFIG_HAS_PCI
++static int flask_assign_device(struct domain *d, unsigned int machine_bdf);
++static int flask_deassign_device(struct domain *d, unsigned int machine_bdf);
++#endif
++#ifdef CONFIG_HAS_DEVICE_TREE
++static int flask_assign_dtdevice(struct domain *d, const char *dtpath);
++static int flask_deassign_dtdevice(struct domain *d, const char *dtpath);
++#endif
++#endif /* CONFIG_HAS_PASSTHROUGH */
++
+ static uint32_t domain_sid(const struct domain *dom)
+ {
+     struct domain_security_struct *dsec = dom->ssid;
+@@ -694,16 +705,6 @@ static int cf_check flask_domctl(struct domain *d, struct xen_domctl *op)
+ 
+     /* These have individual XSM hooks (common/domctl.c) */
+     case XEN_DOMCTL_set_target:
+-
+-#ifdef CONFIG_HAS_PASSTHROUGH
+-    /*
+-     * These have individual XSM hooks
+-     * (drivers/passthrough/{pci,device_tree.c)
+-     */
+-    case XEN_DOMCTL_test_assign_device:
+-    case XEN_DOMCTL_assign_device:
+-    case XEN_DOMCTL_deassign_device:
+-#endif
+         return 0;
+ 
+     case XEN_DOMCTL_destroydomain:
+@@ -783,6 +784,49 @@ static int cf_check flask_domctl(struct domain *d, struct xen_domctl *op)
+         return flask_shadow_control(d, op->u.shadow_op.op);
+ #endif
+ 
++#ifdef CONFIG_HAS_PASSTHROUGH
++
++    case XEN_DOMCTL_test_assign_device:
++    case XEN_DOMCTL_assign_device:
++    case XEN_DOMCTL_deassign_device:
++        switch ( op->u.assign_device.dev )
++        {
++#ifdef CONFIG_HAS_PCI
++        case XEN_DOMCTL_DEV_PCI:
++            return op->cmd != XEN_DOMCTL_deassign_device
++                   ? flask_assign_device(
++                         d, op->u.assign_device.u.pci.machine_sbdf)
++                   : flask_deassign_device(
++                         d, op->u.assign_device.u.pci.machine_sbdf);
++#endif
++
++#ifdef CONFIG_HAS_DEVICE_TREE
++        case XEN_DOMCTL_DEV_DT:
++        {
++            struct dt_device_node *dev;
++            int ret = dt_find_node_by_gpath(op->u.assign_device.u.dt.path,
++                                            op->u.assign_device.u.dt.size,
++                                            &dev);
++
++            if ( ret )
++                return ret;
++
++            op->u.assign_device.u.dt.dev = dev;
++
++            return op->cmd != XEN_DOMCTL_deassign_device
++                   ? flask_assign_dtdevice(d, dt_node_full_name(dev))
++                   : flask_deassign_dtdevice(d, dt_node_full_name(dev));
++        }
++#endif
++
++        default:
++            /* Unknown type. */
++            break;
++        }
++        return avc_unknown_permission("assign_device", op->cmd);
++
++#endif /* CONFIG_HAS_PASSTHROUGH */
++
+     case XEN_DOMCTL_mem_sharing_op:
+         return current_has_perm(d, SECCLASS_HVM, HVM__MEM_SHARING);
+ 
+@@ -1397,7 +1441,7 @@ static int flask_test_assign_device(uint32_t machine_bdf)
+     return avc_current_has_perm(rsid, SECCLASS_RESOURCE, RESOURCE__STAT_DEVICE, NULL);
+ }
+ 
+-static int cf_check flask_assign_device(struct domain *d, uint32_t machine_bdf)
++static int flask_assign_device(struct domain *d, uint32_t machine_bdf)
+ {
+     uint32_t dsid, rsid;
+     int rc = -EPERM;
+@@ -1427,7 +1471,7 @@ static int cf_check flask_assign_device(struct domain *d, uint32_t machine_bdf)
+     return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, dperm, &ad);
+ }
+ 
+-static int cf_check flask_deassign_device(
++static int flask_deassign_device(
+     struct domain *d, uint32_t machine_bdf)
+ {
+     uint32_t rsid;
+@@ -1459,7 +1503,7 @@ static int flask_test_assign_dtdevice(const char *dtpath)
+                                 NULL);
+ }
+ 
+-static int cf_check flask_assign_dtdevice(struct domain *d, const char *dtpath)
++static int flask_assign_dtdevice(struct domain *d, const char *dtpath)
+ {
+     uint32_t dsid, rsid;
+     int rc = -EPERM;
+@@ -1489,7 +1533,7 @@ static int cf_check flask_assign_dtdevice(struct domain *d, const char *dtpath)
+     return avc_has_perm(dsid, rsid, SECCLASS_RESOURCE, dperm, &ad);
+ }
+ 
+-static int cf_check flask_deassign_dtdevice(
++static int flask_deassign_dtdevice(
+     struct domain *d, const char *dtpath)
+ {
+     uint32_t rsid;
+@@ -1950,13 +1994,6 @@ static const struct xsm_ops __initconst_cf_clobber flask_ops = {
+ 
+ #if defined(CONFIG_HAS_PASSTHROUGH) && defined(CONFIG_HAS_PCI)
+     .get_device_group = flask_get_device_group,
+-    .assign_device = flask_assign_device,
+-    .deassign_device = flask_deassign_device,
+-#endif
+-
+-#if defined(CONFIG_HAS_PASSTHROUGH) && defined(CONFIG_HAS_DEVICE_TREE)
+-    .assign_dtdevice = flask_assign_dtdevice,
+-    .deassign_dtdevice = flask_deassign_dtdevice,
+ #endif
+ 
+     .platform_op = flask_platform_op,
+-- 
+2.53.0
+

--- a/SOURCES/0018-domctl-handle-XEN_DOMCTL_set_target-without-acquirin.patch
+++ b/SOURCES/0018-domctl-handle-XEN_DOMCTL_set_target-without-acquirin.patch
@@ -1,0 +1,145 @@
+From 0e239db9305444f573f1e1977e8bec3b0e02d24a Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Fri, 5 Jun 2026 15:40:19 +0200
+Subject: [PATCH 18/18] domctl: handle XEN_DOMCTL_set_target without acquiring
+ domctl lock
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+The only locking required here is that between checking d->target and
+setting it. To avoid the need for an explicit lock, use cmpxchgptr() to
+update d->target.
+
+Move the handling not only ahead of acquiring the lock, but also ahead
+of the XSM check, leveraging that the sub-op has its own hook.
+
+This is part of XSA-492.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Acked-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+Reviewed-by: Roger Pau Monné <roger.pau@citrix.com>
+---
+ xen/common/domctl.c     | 54 ++++++++++++++++++-----------------------
+ xen/include/xsm/dummy.h |  3 ++-
+ xen/xsm/flask/hooks.c   |  5 +---
+ 3 files changed, 27 insertions(+), 35 deletions(-)
+
+diff --git a/xen/common/domctl.c b/xen/common/domctl.c
+index bf97dc8a36..a2d51267c5 100644
+--- a/xen/common/domctl.c
++++ b/xen/common/domctl.c
+@@ -489,6 +489,30 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         goto domctl_out_unlock_domonly;
+     }
+ 
++    case XEN_DOMCTL_set_target:
++    {
++        struct domain *e = get_domain_by_id(op->u.set_target.target);
++
++        ret = -ESRCH;
++        if ( !e )
++            goto domctl_out_unlock_domonly;
++
++        if ( d == e )
++            ret = -EINVAL;
++        else if ( !is_hvm_domain(e) )
++            ret = -EOPNOTSUPP;
++        else
++            ret = xsm_set_target(XSM_PRIV, d, e);
++
++        /* Hold reference on @e until we destroy @d. */
++        if ( !ret && cmpxchgptr(&d->target, NULL, e) )
++            ret = -EINVAL;
++
++        if ( ret )
++            put_domain(e);
++        goto domctl_out_unlock_domonly;
++    }
++
+     case XEN_DOMCTL_vm_event_op:
+         if ( op->u.vm_event_op.op == XEN_VM_EVENT_GET_VERSION )
+         {
+@@ -846,36 +870,6 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+         domain_set_time_offset(d, op->u.settimeoffset.time_offset_seconds);
+         break;
+ 
+-    case XEN_DOMCTL_set_target:
+-    {
+-        struct domain *e;
+-
+-        ret = -ESRCH;
+-        e = get_domain_by_id(op->u.set_target.target);
+-        if ( e == NULL )
+-            break;
+-
+-        ret = -EINVAL;
+-        if ( (d == e) || (d->target != NULL) )
+-        {
+-            put_domain(e);
+-            break;
+-        }
+-
+-        ret = -EOPNOTSUPP;
+-        if ( is_hvm_domain(e) )
+-            ret = xsm_set_target(XSM_HOOK, d, e);
+-        if ( ret )
+-        {
+-            put_domain(e);
+-            break;
+-        }
+-
+-        /* Hold reference on @e until we destroy @d. */
+-        d->target = e;
+-        break;
+-    }
+-
+     case XEN_DOMCTL_subscribe:
+         d->suspend_evtchn = op->u.subscribe.port;
+         break;
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index dfc4dec46a..b1417abfa8 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -150,7 +150,7 @@ static XSM_INLINE int cf_check xsm_sysctl_scheduler_op(XSM_DEFAULT_ARG int cmd)
+ static XSM_INLINE int cf_check xsm_set_target(
+     XSM_DEFAULT_ARG struct domain *d, struct domain *e)
+ {
+-    XSM_ASSERT_ACTION(XSM_HOOK);
++    XSM_ASSERT_ACTION(XSM_PRIV);
+     return xsm_default_action(action, current->domain, NULL);
+ }
+ 
+@@ -168,6 +168,7 @@ static XSM_INLINE int cf_check xsm_domctl(
+     case XEN_DOMCTL_ioport_permission:
+     case XEN_DOMCTL_irq_permission:
+     case XEN_DOMCTL_memory_mapping:
++    case XEN_DOMCTL_set_target:
+     case XEN_DOMCTL_unbind_pt_irq:
+         ASSERT_UNREACHABLE();
+         return -EILSEQ;
+diff --git a/xen/xsm/flask/hooks.c b/xen/xsm/flask/hooks.c
+index 579e977284..33fedd46b8 100644
+--- a/xen/xsm/flask/hooks.c
++++ b/xen/xsm/flask/hooks.c
+@@ -699,14 +699,11 @@ static int cf_check flask_domctl(struct domain *d, struct xen_domctl *op)
+     case XEN_DOMCTL_ioport_permission:
+     case XEN_DOMCTL_irq_permission:
+     case XEN_DOMCTL_memory_mapping:
++    case XEN_DOMCTL_set_target:
+     case XEN_DOMCTL_unbind_pt_irq:
+         ASSERT_UNREACHABLE();
+         return -EILSEQ;
+ 
+-    /* These have individual XSM hooks (common/domctl.c) */
+-    case XEN_DOMCTL_set_target:
+-        return 0;
+-
+     case XEN_DOMCTL_destroydomain:
+         return current_has_perm(d, SECCLASS_DOMAIN, DOMAIN__DESTROY);
+ 
+-- 
+2.53.0
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -31,7 +31,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.6
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.6.tar.gz
@@ -311,7 +311,29 @@ Patch268: xen-spec-ctrl-utility.patch
 Patch269: vtpm-ppi-acpi-dsm.patch
 
 # XCP-ng patches
-#Patch1000:
+# XSA-491
+Patch1000: 0001-x86-HVM-add-locking-to-I-O-port-translation-list-tra.patch
+# XSA-492
+Patch1001: 0001-xen-xsm-make-getdomaininfo-xsm-dummy-checks-more-str.patch
+Patch1002: 0002-sched-use-sequence-counter-to-enlighten-vcpu_runstat.patch
+Patch1003: 0003-domctl-handle-XEN_DOMCTL_getdomaininfo-without-acqui.patch
+Patch1004: 0004-domain-locking-for-iomem_caps-accesses.patch
+Patch1005: 0005-x86-domain-locking-for-ioport_caps-accesses.patch
+Patch1006: 0006-domain-locking-for-irq_caps-accesses.patch
+Patch1007: 0007-domctl-handle-XEN_DOMCTL_memory_mapping-without-acqu.patch
+Patch1008: 0008-domctl-handle-XEN_DOMCTL_ioport_mapping-without-acqu.patch
+Patch1009: 0009-domctl-handle-XEN_DOMCTL_-un-bind_pt_irq-without-acq.patch
+Patch1010: 0010-domctl-handle-XEN_DOMCTL_io-mem-port-_permission-wit.patch
+Patch1011: 0011-domctl-handle-XEN_DOMCTL_irq_permission-without-acqu.patch
+Patch1012: 0012-domctl-XSM-drop-vm_event_control-hook.patch
+Patch1013: 0013-domctl-XSM-pass-full-struct-xen_domctl-to-xsm_domctl.patch
+Patch1014: 0014-domctl-XSM-drop-scheduler_op-hook.patch
+Patch1015: 0015-domctl-XSM-drop-shadow_control_op-hook.patch
+Patch1016: 0016-domctl-handle-XEN_DOMCTL_get_device_group-without-ac.patch
+Patch1017: 0017-domctl-XSM-drop-de-assign_-dt-device-hooks.patch
+Patch1018: 0018-domctl-handle-XEN_DOMCTL_set_target-without-acquirin.patch
+# XSA-494
+Patch1019: 0001-x86-mm-accurately-track-which-vCPU-page-tables-are-l.patch
 
 ExclusiveArch: x86_64
 
@@ -1159,6 +1181,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Fri Jun 05 2026 Thierry Escande <thierry.escande@vates.tech> - 4.17.6-9.2
+- Backport patches for XSA-491, XSA-492, and XSA-494
+
 * Wed May 13 2026 Thierry Escande <thierry.escande@vates.tech> - 4.17.6-9.1
 - Sync with XenServer 4.17.6-9
 - *** Upstream changelog ***


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3338

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Backport patches for XSA-491, XSA-492, and XSA-494

#### Release Target

- [X] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

```
This release adds fixes for the following security issues:

XSA-491
All Xen version from at least 3.2 and onwards are vulnerable. This concerns Xen hosts running x86 HVM guests where the device model (e.g., QEMU) is controlled or compromised. This could possibly cause a Denial of Service (DoS) of the entire host and possible privilege escalation and information leaks.
There is no mitigation.

XSA-492
All Xen version from 3.3 and onwards are vulnerable to this issue. An attacker with control over a less privileged entity may stall an equally or more privileged entity, potentially leading to a Denial od Service (DoS) of up to the entire host.
There is no known mitigation.
```

No need to mention XSA-494 as it only concerns PV guests and thus XCP-ng is not impacted.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

<!-- Add links to the documentation update PRs if/when they are created. -->

Only bug fixes, no functional changes.

PR links: N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

- Local build
- Package Installation
- pytest vm-basic-operations

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

N/A

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Usual CI tests for regression tests

#### What tests have been or will be added to CI for this change? If none, explain why.

None. This is not covered by existing tests but it would be hard to do so as it implies a compromised Qemu for XSA-491 and a compromised control domain other than dom0 for XSA-492. We will have to check if new tests are added to the XTF after the end of the embargo.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
