### PR TITLE
Backport UEFI GOP bugfixes

### DIFF
--- a/SOURCES/0001-multiboot2-parse-vga-option-when-setting-GOP-mode.patch
+++ b/SOURCES/0001-multiboot2-parse-vga-option-when-setting-GOP-mode.patch
@@ -1,0 +1,173 @@
+From d75ffbef3be21aabe0e3174c464e99327ae7b61d Mon Sep 17 00:00:00 2001
+Message-ID: <d75ffbef3be21aabe0e3174c464e99327ae7b61d.1782890521.git.teddy.astie@vates.tech>
+From: =?UTF-8?q?Roger=20Pau=20Monn=C3=A9?= <roger.pau@citrix.com>
+Date: Mon, 10 Jul 2023 12:17:45 +0200
+Subject: [PATCH] multiboot2: parse vga= option when setting GOP mode
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Introduce support for passing the command line to the efi_multiboot2()
+helper, and parse the vga= option if present.
+
+Add support for the 'gfx' and 'current' vga options, ignore the 'keep'
+option, and print a warning message about other options not being
+currently implemented.
+
+Note that the multboot2 command line string must always be
+zero-terminated according to the multiboot2 specification, and hence
+there's no need to pass the string size to efi_multiboot2().
+
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+(cherry picked from commit c93aa5c5d0a9f92c0a62c1992d5e52435fa24f15)
+---
+ xen/arch/x86/boot/head.S          | 13 +++++-
+ xen/arch/x86/efi/efi-boot.h       | 74 ++++++++++++++++++++++++++++++-
+ xen/arch/x86/x86_64/asm-offsets.c |  1 +
+ 3 files changed, 84 insertions(+), 4 deletions(-)
+
+diff --git a/xen/arch/x86/boot/head.S b/xen/arch/x86/boot/head.S
+index 3678f615bc..4999705395 100644
+--- a/xen/arch/x86/boot/head.S
++++ b/xen/arch/x86/boot/head.S
+@@ -240,9 +240,10 @@ __efi64_mb2_start:
+         jmp     x86_32_switch
+ 
+ .Lefi_multiboot2_proto:
+-        /* Zero EFI SystemTable and EFI ImageHandle addresses. */
++        /* Zero EFI SystemTable, EFI ImageHandle addresses and cmdline. */
+         xor     %esi,%esi
+         xor     %edi,%edi
++        xor     %edx,%edx
+ 
+         /* Skip Multiboot2 information fixed part. */
+         lea     (MB2_fixed_sizeof+MULTIBOOT2_TAG_ALIGN-1)(%rbx),%ecx
+@@ -280,6 +281,13 @@ __efi64_mb2_start:
+         cmove   MB2_efi64_ih(%rcx),%rdi
+         je      .Lefi_mb2_next_tag
+ 
++        /* Get command line from Multiboot2 information. */
++        cmpl    $MULTIBOOT2_TAG_TYPE_CMDLINE, MB2_tag_type(%rcx)
++        jne     .Lno_cmdline
++        lea     MB2_tag_string(%rcx), %rdx
++        jmp     .Lefi_mb2_next_tag
++.Lno_cmdline:
++
+         /* Is it the end of Multiboot2 information? */
+         cmpl    $MULTIBOOT2_TAG_TYPE_END,MB2_tag_type(%rcx)
+         je      .Lrun_bs
+@@ -343,7 +351,8 @@ __efi64_mb2_start:
+ 
+         /*
+          * efi_multiboot2() is called according to System V AMD64 ABI:
+-         *   - IN:  %rdi - EFI ImageHandle, %rsi - EFI SystemTable.
++         *   - IN:  %rdi - EFI ImageHandle, %rsi - EFI SystemTable,
++         *          %rdx - MB2 cmdline
+          */
+         call    efi_multiboot2
+ 
+diff --git a/xen/arch/x86/efi/efi-boot.h b/xen/arch/x86/efi/efi-boot.h
+index 64c1a02cf1..88e715f4dd 100644
+--- a/xen/arch/x86/efi/efi-boot.h
++++ b/xen/arch/x86/efi/efi-boot.h
+@@ -795,7 +795,30 @@ static bool __init efi_arch_use_config_file(EFI_SYSTEM_TABLE *SystemTable)
+ 
+ static void __init efi_arch_flush_dcache_area(const void *vaddr, UINTN size) { }
+ 
+-void __init efi_multiboot2(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
++/* Return a pointer to the character after the first occurrence of opt in cmd */
++static const char *__init get_option(const char *cmd, const char *opt)
++{
++    const char *s = cmd, *o = NULL;
++
++    if ( !cmd || !opt )
++        return NULL;
++
++    while ( (s = strstr(s, opt)) != NULL )
++    {
++        if ( s == cmd || *(s - 1) == ' ' || *(s - 1) == '\t' )
++        {
++            o = s + strlen(opt);
++            break;
++        }
++
++        s += strlen(opt);
++    }
++
++    return o;
++}
++
++void __init efi_multiboot2(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable,
++                           const char *cmdline)
+ {
+     EFI_GRAPHICS_OUTPUT_PROTOCOL *gop;
+     EFI_HANDLE gop_handle;
+@@ -816,7 +839,54 @@ void __init efi_multiboot2(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable
+ 
+     if ( gop )
+     {
+-        gop_mode = efi_find_gop_mode(gop, 0, 0, 0);
++        const char *cur = cmdline;
++        unsigned int width = 0, height = 0, depth = 0;
++        bool keep_current = false;
++
++        while ( (cur = get_option(cur, "vga=")) != NULL )
++        {
++#define VALID_TERMINATOR(c) \
++    (*(c) == ' ' || *(c) == '\t' || *(c) == '\0' || *(c) == ',')
++            if ( !strncmp(cur, "gfx-", 4) )
++            {
++                width = simple_strtoul(cur + 4, &cur, 10);
++
++                if ( *cur == 'x' )
++                    height = simple_strtoul(cur + 1, &cur, 10);
++                else
++                    goto error;
++
++                if ( *cur == 'x' )
++                    depth = simple_strtoul(cur + 1, &cur, 10);
++                else
++                    goto error;
++
++                if ( !VALID_TERMINATOR(cur) )
++                {
++                error:
++                    PrintErr(L"Warning: Invalid gfx- option detected\r\n");
++                    width = height = depth = 0;
++                }
++                keep_current = false;
++            }
++            else if ( !strncmp(cur, "current", 7) && VALID_TERMINATOR(cur + 7) )
++                keep_current = true;
++            else if ( !strncmp(cur, "keep", 4) && VALID_TERMINATOR(cur + 4) )
++            {
++                /* Ignore, handled in later vga= parsing. */
++            }
++            else
++            {
++                /* Fallback to defaults if unimplemented. */
++                width = height = depth = 0;
++                keep_current = false;
++                PrintErr(L"Warning: Cannot use selected vga option\r\n");
++            }
++#undef VALID_TERMINATOR
++        }
++
++        if ( !keep_current )
++            gop_mode = efi_find_gop_mode(gop, width, height, depth);
+ 
+         efi_arch_edid(gop_handle);
+     }
+diff --git a/xen/arch/x86/x86_64/asm-offsets.c b/xen/arch/x86/x86_64/asm-offsets.c
+index 15496fedb7..690fa8def5 100644
+--- a/xen/arch/x86/x86_64/asm-offsets.c
++++ b/xen/arch/x86/x86_64/asm-offsets.c
+@@ -282,6 +282,7 @@ void __dummy__(void)
+     OFFSET(MB2_mem_lower, multiboot2_tag_basic_meminfo_t, mem_lower);
+     OFFSET(MB2_efi64_st, multiboot2_tag_efi64_t, pointer);
+     OFFSET(MB2_efi64_ih, multiboot2_tag_efi64_ih_t, pointer);
++    OFFSET(MB2_tag_string, multiboot2_tag_string_t, string);
+     BLANK();
+ 
+     OFFSET(DOMAIN_vm_assist, struct domain, vm_assist);

--- a/SOURCES/0002-multiboot2-do-not-set-StdOut-mode-unconditionally.patch
+++ b/SOURCES/0002-multiboot2-do-not-set-StdOut-mode-unconditionally.patch
@@ -1,0 +1,41 @@
+From 75d8b5c71a2a975ceb231207a0a31d66e3af196d Mon Sep 17 00:00:00 2001
+Message-ID: <75d8b5c71a2a975ceb231207a0a31d66e3af196d.1782890521.git.teddy.astie@vates.tech>
+In-Reply-To: <d75ffbef3be21aabe0e3174c464e99327ae7b61d.1782890521.git.teddy.astie@vates.tech>
+References: <d75ffbef3be21aabe0e3174c464e99327ae7b61d.1782890521.git.teddy.astie@vates.tech>
+From: =?UTF-8?q?Roger=20Pau=20Monn=C3=A9?= <roger.pau@citrix.com>
+Date: Mon, 10 Jul 2023 12:18:39 +0200
+Subject: [PATCH] multiboot2: do not set StdOut mode unconditionally
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Only initialize StdOut if the current StdOut mode is unusable.  This
+avoids forcefully switching StdOut to the maximum supported
+resolution, and thus very likely changing the GOP mode without having
+first parsed the command line options.
+
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+---
+ xen/arch/x86/efi/efi-boot.h | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/xen/arch/x86/efi/efi-boot.h b/xen/arch/x86/efi/efi-boot.h
+index 88e715f4dd..92f4cfe8bd 100644
+--- a/xen/arch/x86/efi/efi-boot.h
++++ b/xen/arch/x86/efi/efi-boot.h
+@@ -829,7 +829,13 @@ void __init efi_multiboot2(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable
+ 
+     efi_init(ImageHandle, SystemTable);
+ 
+-    efi_console_set_mode();
++    if ( StdOut->QueryMode(StdOut, StdOut->Mode->Mode,
++                           &cols, &rows) != EFI_SUCCESS )
++        /*
++         * If active StdOut mode is invalid init ConOut (StdOut) to the max
++         * supported size.
++         */
++        efi_console_set_mode();
+ 
+     if ( StdOut->QueryMode(StdOut, StdOut->Mode->Mode,
+                            &cols, &rows) == EFI_SUCCESS )

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -31,7 +31,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.6
-Release: %{?xsrel}.4%{?dist}
+Release: %{?xsrel}.5%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.6.tar.gz
@@ -346,6 +346,10 @@ Patch1026: dts-0007-xenpm-Add-get-core-temp-subcommand.patch
 
 # EFI_SET_VIRTUAL_ADDRESS_MAP
 Patch1027: 0001-efi-Enable-EFI_SET_VIRTUAL_ADDRESS_MAP-by-default.patch
+
+# UEFI GOP bugfixes
+Patch1028: 0001-multiboot2-parse-vga-option-when-setting-GOP-mode.patch
+Patch1029: 0002-multiboot2-do-not-set-StdOut-mode-unconditionally.patch
 
 ExclusiveArch: x86_64
 
@@ -1193,6 +1197,10 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Tue Jun 30 2026 Teddy Astie <teddy.astie@vates.tech> - 4.17.6-9.5
+- Backport UEFI GOP bugfixes fixing ignored vga=... cmdline and erroneously
+  forced maximum resolution.
+
 * Thu Jun 18 2026 Teddy Astie <teddy.astie@vates.tech> - 4.17.6-9.4
 - Enable EFI_SET_VIRTUAL_ADDRESS_MAP by default to fix boot failure on
   some systems with UEFI.


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3391

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

https://github.com/xen-project/xen/commit/c93aa5c5d0a9f92c0a62c1992d5e52435fa24f15
https://github.com/xen-project/xen/commit/60474e8e281807f384f4768a464d71406d0cf659

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

2 bugs are fixed in these updates : 
- The Xen logic is erroneously setting the maximum screen resolution even if the current one is correct.
  That can lead to out of range display errors or way too high resolutions (and hard to read text).
- vga cmdline parameter is ignored, preventing to workaround the first issue.

Related to https://github.com/xcp-ng/xcp-ng-org/issues/255

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

8.3-next+1

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Fix bug causing UEFI logic to set inappropriate screen resolutions.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

May change the effective resolution people are having in Host UEFI mode (for better or worse, in the meaning, maximum resolution may be higher than initial firmware one).

The change makes the display management more in line to what we have in BIOS mode.

#### Documentation update needed

- [x] Yes
- [ ] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

~~Given that it fixes vga=... parameter, it may be useful if people want to tweak it for their need.
It's very machine specific and quite complicated, and most people don't care about it anyway (unless they have no display in XCP-ng).~~
https://github.com/xcp-ng/xcp-ng-org/pull/491

<!-- Add links to the documentation update PRs if/when they are created. -->

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

Worst case regression : the bios/grub has bogus resolution, and we keep it. This is already a user problem before being a XCP-ng one, and can be workaround anyway (as we fix vga=... parameter).

#### What tests have you performed?

Test in QEMU with high VRAM amount that the screen doesn't go in extreme resolutions anymore.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

* A manual test should be done with an ISO installer containing this fix to make sure the installer starts correctly
even if the firmware has a low resolution or misconfigures the display.
* A test to test the resolution fallback via `vga=` xen cmdline parameter

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

None

#### What tests have been or will be added to CI for this change? If none, explain why.

None added so far.
But in the future we could add a test that automates testing of firmware setting a very low display resolution.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.
