### PR TITLE
xenguest: accept mem_pnode in EMP path (xg_emu.c)

### DIFF
--- a/SOURCES/xenguest-xg_emu-mem_pnode.patch
+++ b/SOURCES/xenguest-xg_emu-mem_pnode.patch
@@ -1,0 +1,54 @@
+From 815e20e1904c51bf1233af086bccf326977fa4b9 Mon Sep 17 00:00:00 2001
+From: Julian Vetter <julian.vetter@vates.tech>
+Date: Tue, 23 Jun 2026 11:24:02 +0200
+Subject: [PATCH] Add mem_pnode support to xenguest EMP path (xg_emu.c)
+
+xenguest.patch added mem_pnode to the CLI option parser and the
+build/restore paths. However the EMP server path (used by
+xcp-emu-manager) receives arguments via cmd_set_args / setable_args,
+which did not include mem_pnode. When xenopsd 25.33+ passes -mem_pnode
+to emu-manager, emu-manager forwards it via cmd_set_args and xenguest
+replies "Bad Args" and the restore fails.
+
+Add arg_mem_pnode to xg_emu.c, register it in setable_args, and
+propagate it to opt_mem_pnode before calling stub_xc_domain_restore so
+that the same NUMA placement logic used by the CLI path is exercised
+over the EMP path too.
+
+Signed-off-by: Julian Vetter <julian.vetter@vates.tech>
+---
+ tools/xenguest/xg_emu.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/tools/xenguest/xg_emu.c b/tools/xenguest/xg_emu.c
+index 959ba6cf1e..f1cfd192ed 100644
+--- a/tools/xenguest/xg_emu.c
++++ b/tools/xenguest/xg_emu.c
+@@ -16,6 +16,7 @@ static int stream_fd = -1;
+ 
+ static int arg_store_port = -1;
+ static int arg_console_port = -1;
++static int arg_mem_pnode = -1;
+ 
+ /* timeout in seconds */
+ #define COMMAND_TIMEOUT (60 * 2)
+@@ -195,6 +196,8 @@ static void do_cmd_restore(emp_call_args *args)
+ 
+     emp_send_return(args->cli, NULL);
+ 
++    opt_mem_pnode = (arg_mem_pnode >= 0) ? (unsigned int)arg_mem_pnode
++                                         : XC_NUMA_NO_NODE;
+     stub_xc_domain_restore(stream_fd, arg_store_port, arg_console_port, !pv_mode,
+                            &store_mfn, &console_mfn);
+ 
+@@ -230,6 +233,7 @@ struct arg_list
+ const static struct arg_list setable_args[] = {
+     {"store_port",   int_type,  .a_int = &arg_store_port},
+     {"console_port", int_type,  .a_int = &arg_console_port},
++    {"mem_pnode",    int_type,  .a_int = &arg_mem_pnode},
+     {"pv",           bool_type, .a_bool = &pv_mode},
+     {"vgpu",         bool_type, .a_bool = &opt_vgpu},
+     {}
+-- 
+2.53.0
+

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -225,6 +225,8 @@ Patch181: elf-note-filtering.patch
 
 %if 0%{?xcpng}
 Patch1000: xcpng-no-default-lockdown.patch
+# Fix xenguest EMP path (xg_emu.c) to accept mem_pnode from emu-manager
+Patch1001: xenguest-xg_emu-mem_pnode.patch
 %endif
 
 ExclusiveArch: %{x86_64}
@@ -1140,6 +1142,8 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Mon Jun 23 2026 Julian Vetter <julian.vetter@vates.tech> - 4.20.2-8.1 WIP
+- Added new mem_pnode argument to xenguest EMP path
 * Mon Apr 20 2026 Yann Dirson <yann.dirson@vates.tech> - 4.20.2-8.1 WIP
 - Sync with 4.20.2-8
 - Dropped xsa467.patch, integrated in xen-4.20, and nested-virt patch, integrated by XS


### PR DESCRIPTION
### Main information

#### Work Item Reference

Work for XCP-ng 9

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

xenopsd 25.33+ passes `-mem_pnode` to emu-manager for NUMA memory placement during VM restore. emu-manager forwards it via `cmd_set_args`, but `xg_emu.c`'s `setable_args` table had no entry for it, causing xenguest
to reply "Bad Args" and the restore to fail.

Add `arg_mem_pnode` to `setable_args` and propagate it to `opt_mem_pnode` before calling `stub_xc_domain_restore`, matching the behavior already present in the CLI path.

#### Release Target

- [X] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

9

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

No changes for the user. Simply a new argument for NUMA memory placement.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

None.

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->


<!-- Add links to the documentation update PRs if/when they are created. -->

N/A

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

CI test `vm_basic_operations.py`

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

None. All test cases are covered by the CI.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Everything is covered.

#### What tests have been or will be added to CI for this change? If none, explain why.

None. See above.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.
