### PR TITLE
Bump to rebuild against new ocaml, ocaml-findlib

### DIFF
--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -31,7 +31,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.6
-Release: %{?xsrel}.5%{?dist}
+Release: %{?xsrel}.6%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.6.tar.gz
@@ -1197,6 +1197,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Mon Jul 20 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 4.17.6-9.6
+- Rebuild against new ocaml, ocaml-findlib versions
+
 * Tue Jun 30 2026 Teddy Astie <teddy.astie@vates.tech> - 4.17.6-9.5
 - Backport UEFI GOP bugfixes fixing ignored vga=... cmdline and erroneously
   forced maximum resolution.


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3422

#### Related changes (optional)

https://github.com/xcp-ng-rpms/ocaml/pull/2 and https://github.com/xcp-ng-rpms/ocaml-findlib/pull/5

#### Context & Motivation

Bump to rebuild against new versions of dependencies

#### Release Target

- [X] We already defined a release target with the release team.

`8.3-next+1`

---

### Release Notes and Documentation

#### Explain the change to users

No user-facing change

#### Attention points

None

#### Documentation update needed

- [X] No

---

### Testing and regression avoidance

Regular CI should cover this update.

#### What tests have you performed?

None

#### What manual tests should be performed after the build, and by whom?

None

#### What's covered by the xcp-ng-tests test suite?

Operation of the OCaml code (oxenstored and xenctrl stubs) is verified as part of the CI 

#### What tests have been or will be added to CI for this change? If none, explain why.

None

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [X] No
