### PR TITLE
8.3 sync fasttrack branch

### DIFF
--- a/SOURCES/xsa497.patch
+++ b/SOURCES/xsa497.patch
@@ -1,0 +1,172 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Syed Abdul Khaliq <abdul@bugqore.com>
+Date: Tue, 21 Jul 2026 12:32:30 +0000
+Subject: [PATCH] libfsimage/iso9660: harden Rock Ridge SUSP parsing against
+ malformed lengths
+
+The directory and Rock Ridge / SUSP walk in iso9660_dir() derives several
+lengths directly from attacker-controlled on-disk fields without validating
+them.  libfsimage is used by pygrub, which parses the filesystem of an
+untrusted guest disk image from dom0, so these are reachable across a trust
+boundary.
+
+Five related problems are addressed:
+
+  * The directory record loop advances by
+
+        idr = (char *)idr + idr->length.l
+
+    and only stops on length.l == 0.  A record whose length is smaller than
+    the fixed part of the on-disk layout cannot hold its own mandatory
+    fields, yet the body still reads name_len/extent/size and computes the
+    System Use area length from it.  Require length to cover at least the
+    fixed record (sizeof(*idr) - sizeof(idr->name)) before entering the body.
+
+    This is CVE-2026-42494.
+
+  * The System Use area length is computed before the inner loop as
+
+        rr_len = idr->length.l - idr->name_len.l
+                 - sizeof(struct iso_directory_record) + sizeof(idr->name);
+
+    in unsigned arithmetic.  If length.l is smaller than name_len.l plus the
+    fixed record size, rr_len underflows to a huge value and the whole SUSP
+    walk runs off the directory buffer.  Guard the subtraction and treat such
+    records as having no System Use area.
+
+    This is CVE-2026-42495.
+
+  * Inside the loop, each entry is consumed with
+
+        rr_len -= rr_ptr.rr->len;
+        rr_ptr.ptr += rr_ptr.rr->len;
+
+    with no lower or upper bound on the entry's own len byte.  A len of 0
+    spins forever; a len greater than the remaining rr_len underflows it and
+    walks past the buffer.  Validate 4 <= len <= rr_len at the top of the
+    loop and stop on violation: a structurally broken entry stream cannot be
+    advanced reliably, so continuing is not meaningful.
+
+    This is CVE-2026-62423.
+
+  * The NM handler subtracted the 5-byte SUSP/NM header from len without a
+    lower-bound check, underflowing name_len (the original report).  The
+    generic check above only guarantees len >= 4; NM has an extra flags byte,
+    so keep an NM-specific len >= 5 check.
+
+    This is CVE-2026-62424.
+
+  * The CE continuation resets rr_ptr/rr_len from ce.offset and ce.size, both
+    image-controlled, into the fixed single-sector RRCONT_BUF with no bounds
+    check.  Reject a window that does not fit in the buffer.
+
+    This is CVE-2026-62425.
+
+This is XSA-497.
+
+Signed-off-by: Syed Abdul Khaliq <abdul@bugqore.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+diff --git a/tools/libfsimage/iso9660/fsys_iso9660.c b/tools/libfsimage/iso9660/fsys_iso9660.c
+index 6e767357bfdc..b1e543afd3ba 100644
+--- a/tools/libfsimage/iso9660/fsys_iso9660.c
++++ b/tools/libfsimage/iso9660/fsys_iso9660.c
+@@ -180,7 +180,15 @@ iso9660_dir (fsi_file_t *ffi, char *dirname)
+ 	  extent++;
+ 
+ 	  idr = (struct iso_directory_record *)DIRREC;
+-	  for (; idr->length.l > 0;
++	  /*
++	   *  length is taken verbatim from the (untrusted) image.  A record
++	   *  shorter than the fixed part of the on-disk layout cannot hold its
++	   *  own mandatory fields (name_len, extent, size, ...), which the loop
++	   *  body reads below; stop the walk rather than dereference past it.
++	   */
++	  for (; idr->length.l >= sizeof(*idr) - sizeof(idr->name)
++		 && idr->length.l
++		    >= sizeof(*idr) - sizeof(idr->name) + idr->name_len.l;
+ 	       idr = (struct iso_directory_record *)((char *)idr + idr->length.l) )
+ 	    {
+ 	      const char *name = (const char *)idr->name;
+@@ -201,21 +209,39 @@ iso9660_dir (fsi_file_t *ffi, char *dirname)
+ 		}
+ 
+ 	      /*
+-	       *  Parse Rock-Ridge extension
++	       *  Parse Rock-Ridge extension.
++	       *
++	       *  length and name_len are taken verbatim from the (untrusted)
++	       *  image.  Reject a record whose name would already overrun the
++	       *  fixed on-disk layout, so that the System Use area length does
++	       *  not underflow to a huge value below.
+ 	       */
+-	      rr_len = (idr->length.l - idr->name_len.l
+-			- sizeof(struct iso_directory_record)
+-			+ sizeof(idr->name));
++	      if (idr->length.l < idr->name_len.l
++		  + sizeof(struct iso_directory_record) - sizeof(idr->name))
++		rr_len = 0;
++	      else
++		rr_len = (idr->length.l - idr->name_len.l
++			  - sizeof(struct iso_directory_record)
++			  + sizeof(idr->name));
+ 	      rr_ptr.ptr = ((char *)idr + idr->name_len.l
+ 			    + sizeof(struct iso_directory_record)
+ 			    - sizeof(idr->name));
+-	      if (rr_ptr.i & 1)
++	      if ((rr_ptr.i & 1) && rr_len)
+ 		rr_ptr.i++, rr_len--;
+ 	      ce_ptr = NULL;
+ 	      rr_flag = RR_FLAG_NM | RR_FLAG_PX /*| RR_FLAG_SL*/;
+ 
+ 	      while (rr_len >= 4)
+ 		{
++		  /*
++		   * A SUSP entry is at least 4 bytes (signature, length,
++		   * version) and must fit in the remaining System Use area.
++		   * A shorter or overlong len is unparseable: stop, rather
++		   * than spin forever (len == 0) or underflow rr_len in the
++		   * advance below (len > rr_len).
++		   */
++		  if (rr_ptr.rr->len < 4 || rr_ptr.rr->len > rr_len)
++		    break;
+ 		  if (rr_ptr.rr->version != 1)
+ 		    {
+ #ifndef STAGE1_5
+@@ -236,9 +262,17 @@ iso9660_dir (fsi_file_t *ffi, char *dirname)
+ 			    rr_flag &= rr_ptr.rr->u.rr.flags.l;
+ 			  break;
+ 			case RRMAGIC('N', 'M'):
+-			  name = (const char *)rr_ptr.rr->u.nm.name;
+-			  name_len = rr_ptr.rr->len - (4+sizeof(struct NM));
+-			  rr_flag &= ~RR_FLAG_NM;
++			  /*
++			   * The generic check above only guarantees len >= 4;
++			   * NM additionally has a flags byte, so len must be at
++			   * least 5 for name_len not to underflow.
++			   */
++			  if (rr_ptr.rr->len >= (4+sizeof(struct NM)))
++			    {
++			      name = (const char *)rr_ptr.rr->u.nm.name;
++			      name_len = rr_ptr.rr->len - (4+sizeof(struct NM));
++			      rr_flag &= ~RR_FLAG_NM;
++			    }
+ 			  break;
+ 			case RRMAGIC('P', 'X'):
+ 			  if (rr_ptr.rr->len >= (4+sizeof(struct PX)))
+@@ -339,6 +373,15 @@ iso9660_dir (fsi_file_t *ffi, char *dirname)
+ 			  memcpy(NAME_BUF, name, name_len);
+ 			  name = (const char *)NAME_BUF;
+ 			}
++		      /*
++		       * offset and size are image-controlled; the loaded
++		       * continuation lives in a single-sector buffer.  Bail
++		       * out if the referenced window does not fit inside it.
++		       */
++		      if (ce_ptr->u.ce.offset.l >= ISO_SECTOR_SIZE
++			  || ce_ptr->u.ce.size.l
++			     > ISO_SECTOR_SIZE - ce_ptr->u.ce.offset.l)
++			break;
+ 		      rr_ptr.ptr = (char *)RRCONT_BUF + ce_ptr->u.ce.offset.l;
+ 		      rr_len = ce_ptr->u.ce.size.l;
+ 		      if (!iso9660_devread(ffi, ce_ptr->u.ce.extent.l, 0, ISO_SECTOR_SIZE, (char *)RRCONT_BUF))

--- a/SOURCES/xsa500.patch
+++ b/SOURCES/xsa500.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Tue, 21 Jul 2026 12:34:26 +0000
+Subject: [PATCH] gnttab: check values against active entry when copying an
+ already-pinned one
+
+acquire_grant_for_copy() passes to its caller both an MFN and a struct
+page_info *. The two really need to be in sync for the get_page()
+underlying get_paged_frame() and get_page_type() (both acting on the
+passed back struct page_info *) and the map_domain_page() (acting on the
+passed back MFN) to achieve the intended effect.
+
+Go further and also check other properties: GTF_transitive / GTF_sub_page
+may have been flipped in the shared entry, so respective fields / values
+also may not match.
+
+The one field which we can be sure does match (as it was checked earlier
+in the function) is ->domid. Add an assertion nevertheless.
+
+This is CVE-2026-62428 / XSA-500.
+
+Fixes: d8cbecb1eeed ("grant-tables: Use get_page_from_gfn() instead of get_gfn()/put_gfn")
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Juergen Gross <jgross@suse.com>
+
+diff --git a/xen/common/grant_table.c b/xen/common/grant_table.c
+index 312d5117ac73..13705c7332e4 100644
+--- a/xen/common/grant_table.c
++++ b/xen/common/grant_table.c
+@@ -2781,6 +2781,21 @@ acquire_grant_for_copy(
+             act->trans_gref = trans_gref;
+             act->mfn = grant_mfn;
+         }
++        else if ( !mfn_eq(act->mfn, grant_mfn) ||
++                  act->trans_domain != td ||
++                  act->trans_gref != trans_gref ||
++                  (act->is_sub_page &&
++                   (!is_sub_page ||
++                    act->start != trans_page_off ||
++                    act->length != trans_length)) )
++        {
++            put_page(*page);
++            *page = NULL;
++            rc = GNTST_general_error;
++            goto unlock_out_clear;
++        }
++        else
++            ASSERT(act->domid == ldom);
+     }
+     else
+     {

--- a/SOURCES/xsa501.patch
+++ b/SOURCES/xsa501.patch
@@ -1,0 +1,289 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Tue, 21 Jul 2026 12:34:37 +0000
+Subject: [PATCH] gnttab: cope with version changes racing other operations
+
+Dropping and re-acquiring the grant table lock for a particular operation
+requires special care, as in the meantime the grant table version can
+change.
+
+During a v2 -> v1 change, status frames going away means that pre-
+calculated status pointers go stale, referencing freed (and possibly
+already re-used) memory. Record in-flight v2 operations, permitting the
+version change only when there are none of them. Recalculate "status" in
+the one place (map_grant_ref()'s error path) where it could be stale, but
+confine this to reserved entries.
+
+Reported-by: Mark Esler <mark@hexproof.dev>
+
+During a v1 -> v2 change, the number of shared table entries reduces,
+meaning that previously validated grant references may now be out of
+bounds.
+
+For gnttab_transfer(), to cover the gap between the lock being dropped by
+gnttab_prepare_for_transfer() and it being re-acquired, have the helper
+return the version it found, and fail the operation if the version turns
+out to have changed after re-acquiring the lock.
+
+Further avoid needless use of shared_entry_header(), as it involves
+pointer arithmetic which, when using an out-of-bounds ref, is UB.
+
+This is XSA-501.
+
+Fixes: a98dc13703e0 ("Introduce a grant_entry_v2 structure")
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Tested-by: Mark Esler <mark@hexproof.dev>
+Acked-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+diff --git a/xen/common/grant_table.c b/xen/common/grant_table.c
+index 13705c7332e4..0ff14c7a090d 100644
+--- a/xen/common/grant_table.c
++++ b/xen/common/grant_table.c
+@@ -71,6 +71,10 @@ struct grant_table {
+     unsigned int          nr_grant_frames;
+     /* Number of grant status frames shared with guest (for version 2) */
+     unsigned int          nr_status_frames;
++
++    /* Number of version 2 operations in progress. */
++    atomic_t              nr_v2_ops;
++
+     /*
+      * Number of available maptrack entries.  For cleanup purposes it is
+      * important to realize that this field and @maptrack further down will
+@@ -1331,11 +1335,28 @@ map_grant_ref(
+ 
+     grant_read_lock(rgt);
+ 
++    if ( unlikely(evaluate_nospec((rgt->gt_version == 1) !=
++                                  (status == &shah->flags))) )
++    {
++        /*
++         * After a v1 -> v2 change behind our backs "ref" may now be out of
++         * bounds.  Recalculate it, but only for reserved entries.  Others
++         * will have been cleared anyway by the version change.
++         */
++        if ( ref < GNTTAB_NR_RESERVED_ENTRIES )
++            status = evaluate_nospec(rgt->gt_version == 1)
++                     ? &shah->flags
++                     : &status_entry(rgt, ref);
++        else
++            status = NULL;
++    }
++
+     act = active_entry_acquire(rgt, op->ref);
+     act->pin -= pin_incr;
+ 
+  unlock_out_clear:
+-    reduce_status_for_pin(rd, act, status, op->flags & GNTMAP_readonly);
++    if ( likely(status) )
++        reduce_status_for_pin(rd, act, status, op->flags & GNTMAP_readonly);
+ 
+  act_release_out:
+     active_entry_release(act);
+@@ -1572,7 +1593,6 @@ unmap_common_complete(struct gnttab_unmap_common *op)
+     struct domain *ld, *rd = op->rd;
+     struct grant_table *rgt;
+     struct active_grant_entry *act;
+-    grant_entry_header_t *sha;
+     struct page_info *pg;
+     uint16_t *status;
+ 
+@@ -1590,10 +1610,9 @@ unmap_common_complete(struct gnttab_unmap_common *op)
+     grant_read_lock(rgt);
+ 
+     act = active_entry_acquire(rgt, op->ref);
+-    sha = shared_entry_header(rgt, op->ref);
+ 
+     if ( evaluate_nospec(rgt->gt_version == 1) )
+-        status = &sha->flags;
++        status = &shared_entry_v1(rgt, op->ref).flags;
+     else
+         status = &status_entry(rgt, op->ref);
+ 
+@@ -2193,14 +2212,14 @@ gnttab_query_size(
+  * Check that the given grant reference (rd,ref) allows 'ld' to transfer
+  * ownership of a page frame. If so, lock down the grant entry.
+  */
+-static int
++static unsigned int
+ gnttab_prepare_for_transfer(
+     struct domain *rd, struct domain *ld, grant_ref_t ref)
+ {
+     struct grant_table *rgt = rd->grant_table;
+     uint32_t *raw_shah;
+     union grant_combo scombo;
+-    int                 retries = 0;
++    unsigned int retries = 0, ver;
+ 
+     grant_read_lock(rgt);
+ 
+@@ -2245,8 +2264,11 @@ gnttab_prepare_for_transfer(
+         scombo = prev;
+     }
+ 
++    ver = rgt->gt_version;
++
+     grant_read_unlock(rgt);
+-    return 1;
++
++    return ver;
+ 
+  fail:
+     grant_read_unlock(rgt);
+@@ -2271,7 +2293,7 @@ gnttab_transfer(
+ 
+     for ( i = 0; i < count; i++ )
+     {
+-        bool_t okay;
++        unsigned int ver;
+         int rc;
+ 
+         if ( i && hypercall_preempt_check() )
+@@ -2411,14 +2433,14 @@ gnttab_transfer(
+          * pagelist.
+          */
+         spin_unlock(&e->page_alloc_lock);
+-        okay = gnttab_prepare_for_transfer(e, d, gop.ref);
++        ver = gnttab_prepare_for_transfer(e, d, gop.ref);
+ 
+         /*
+          * Make sure the reference bound check in gnttab_prepare_for_transfer
+          * is respected and speculative execution is blocked accordingly
+          */
+-        if ( unlikely(!evaluate_nospec(okay)) ||
+-            unlikely(assign_pages(page, 1, e, MEMF_no_refcount)) )
++        if ( unlikely(!evaluate_nospec(ver)) ||
++             unlikely(assign_pages(page, 1, e, MEMF_no_refcount)) )
+         {
+             bool drop_dom_ref;
+ 
+@@ -2430,7 +2452,7 @@ gnttab_transfer(
+             drop_dom_ref = !domain_adjust_tot_pages(e, -1);
+             spin_unlock(&e->page_alloc_lock);
+ 
+-            if ( okay /* i.e. e->is_dying due to the surrounding if() */ )
++            if ( ver /* i.e. e->is_dying due to the surrounding if() */ )
+                 gdprintk(XENLOG_INFO, "Transferee d%d is now dying\n",
+                          e->domain_id);
+ 
+@@ -2450,7 +2472,13 @@ gnttab_transfer(
+         grant_read_lock(e->grant_table);
+         act = active_entry_acquire(e->grant_table, gop.ref);
+ 
+-        if ( evaluate_nospec(e->grant_table->gt_version == 1) )
++        if ( unlikely(evaluate_nospec(e->grant_table->gt_version != ver)) )
++        {
++            rc = -EILSEQ;
++            goto release;
++        }
++
++        if ( evaluate_nospec(ver == 1) )
+         {
+             grant_entry_v1_t *sha = &shared_entry_v1(e->grant_table, gop.ref);
+ 
+@@ -2470,6 +2498,7 @@ gnttab_transfer(
+         shared_entry_header(e->grant_table, gop.ref)->flags |=
+             GTF_transfer_completed;
+ 
++    release:
+         active_entry_release(act);
+         grant_read_unlock(e->grant_table);
+ 
+@@ -2498,7 +2527,6 @@ release_grant_for_copy(
+     struct domain *rd, grant_ref_t gref, bool readonly)
+ {
+     struct grant_table *rgt = rd->grant_table;
+-    grant_entry_header_t *sha;
+     struct active_grant_entry *act;
+     mfn_t mfn;
+     uint16_t *status;
+@@ -2508,12 +2536,11 @@ release_grant_for_copy(
+     grant_read_lock(rgt);
+ 
+     act = active_entry_acquire(rgt, gref);
+-    sha = shared_entry_header(rgt, gref);
+     mfn = act->mfn;
+ 
+     if ( evaluate_nospec(rgt->gt_version == 1) )
+     {
+-        status = &sha->flags;
++        status = &shared_entry_v1(rgt, gref).flags;
+         td = rd;
+         trans_gref = gref;
+     }
+@@ -2537,6 +2564,9 @@ release_grant_for_copy(
+ 
+     reduce_status_for_pin(rd, act, status, readonly);
+ 
++    if ( !act->pin && act->is_sub_page )
++        atomic_dec(&rgt->nr_v2_ops);
++
+     active_entry_release(act);
+     grant_read_unlock(rgt);
+ 
+@@ -2649,8 +2679,10 @@ acquire_grant_for_copy(
+ 
+         /*
+          * acquire_grant_for_copy() will take the lock on the remote table,
+-         * so we have to drop the lock here and reacquire.
++         * so we have to drop the lock here and reacquire.  Before doing so,
++         * record that a v2 operation is in progress.
+          */
++        atomic_inc(&rgt->nr_v2_ops);
+         active_entry_release(act);
+         grant_read_unlock(rgt);
+ 
+@@ -2664,6 +2696,7 @@ acquire_grant_for_copy(
+ 
+         if ( rc != GNTST_okay )
+         {
++            atomic_dec(&rgt->nr_v2_ops);
+             rcu_unlock_domain(td);
+             reduce_status_for_pin(rd, act, status, readonly);
+             active_entry_release(act);
+@@ -2700,6 +2733,8 @@ acquire_grant_for_copy(
+             rcu_unlock_domain(td);
+ 
+             grant_read_lock(rgt);
++            atomic_dec(&rgt->nr_v2_ops);
++
+             act = active_entry_acquire(rgt, gref);
+             reduce_status_for_pin(rd, act, status, readonly);
+             active_entry_release(act);
+@@ -2726,6 +2761,8 @@ acquire_grant_for_copy(
+              */
+             act->is_sub_page = true;
+         }
++        else
++            atomic_dec(&rgt->nr_v2_ops);
+     }
+     else if ( !old_pin ||
+               (!readonly && !(old_pin & (GNTPIN_devw_mask|GNTPIN_hstw_mask))) )
+@@ -2780,6 +2817,9 @@ acquire_grant_for_copy(
+             act->trans_domain = td;
+             act->trans_gref = trans_gref;
+             act->mfn = grant_mfn;
++
++            if ( is_sub_page )
++                atomic_inc(&rgt->nr_v2_ops);
+         }
+         else if ( !mfn_eq(act->mfn, grant_mfn) ||
+                   act->trans_domain != td ||
+@@ -3199,7 +3239,17 @@ gnttab_set_version(XEN_GUEST_HANDLE_PARAM(gnttab_set_version_t) uop)
+         if ( res < 0)
+             goto out_unlock;
+         break;
++
+     case 2:
++        if ( atomic_read(&gt->nr_v2_ops) )
++        {
++            gdprintk(XENLOG_WARNING,
++                     "tried to change to grant table v1, but %d v2 operations still in progress\n",
++                     atomic_read(&gt->nr_v2_ops));
++            res = -EAGAIN;
++            goto out_unlock;
++        }
++
+         for ( i = 0; i < GNTTAB_NR_RESERVED_ENTRIES; i++ )
+         {
+             switch ( shared_entry_v2(gt, i).hdr.flags & GTF_type_mask )

--- a/SOURCES/xsa503.patch
+++ b/SOURCES/xsa503.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Wed, 15 Jul 2026 12:44:37 +0200
+Subject: [PATCH] x86/vrtc: fix race in CMOS index checking
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Do the checking for a valid CMOS index while holding the spinlock,
+otherwise the value could be changed by the guest after having been
+checked.
+
+This is XSA-503 / CVE-2026-62430.
+
+Fixes: 34bef0e6d5f4 ("hvm: Add locking to platform timers.")
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+diff --git a/xen/arch/x86/hvm/rtc.c b/xen/arch/x86/hvm/rtc.c
+index f58228063790..8e77cf39151f 100644
+--- a/xen/arch/x86/hvm/rtc.c
++++ b/xen/arch/x86/hvm/rtc.c
+@@ -645,16 +645,24 @@ static int update_in_progress(RTCState *s)
+     return 0;
+ }
+ 
+-static uint32_t rtc_ioport_read(RTCState *s, uint32_t addr)
++static bool rtc_ioport_read(RTCState *s, uint32_t addr, uint32_t *val)
+ {
+     int ret;
+     struct domain *d = vrtc_domain(s);
+ 
++    *val = ~0;
++
+     if ( (addr & 1) == 0 )
+-        return 0xff;
++        return true;
+ 
+     spin_lock(&s->lock);
+ 
++    if ( s->hw.cmos_index >= RTC_CMOS_SIZE )
++    {
++        spin_unlock(&s->lock);
++        return false;
++    }
++
+     switch ( s->hw.cmos_index )
+     {
+     case RTC_SECONDS:
+@@ -694,7 +702,9 @@ static uint32_t rtc_ioport_read(RTCState *s, uint32_t addr)
+ 
+     spin_unlock(&s->lock);
+ 
+-    return ret;
++    *val = ret;
++
++    return true;
+ }
+ 
+ static int cf_check handle_rtc_io(
+@@ -714,11 +724,8 @@ static int cf_check handle_rtc_io(
+         if ( rtc_ioport_write(vrtc, port, (uint8_t)*val) )
+             return X86EMUL_OKAY;
+     }
+-    else if ( vrtc->hw.cmos_index < RTC_CMOS_SIZE )
+-    {
+-        *val = rtc_ioport_read(vrtc, port);
++    else if ( rtc_ioport_read(vrtc, port, val) )
+         return X86EMUL_OKAY;
+-    }
+ 
+     return X86EMUL_UNHANDLEABLE;
+ }

--- a/SOURCES/xsa504.patch
+++ b/SOURCES/xsa504.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Fri, 10 Jul 2026 15:18:12 +0200
+Subject: [PATCH] x86/viridian: ensure count is always set when starting a
+ timer
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Otherwise in periodic mode a division by 0 would happen on the second call
+to start_stimer() when using periodic mode.
+
+Note that the HyperV specification states: "Writing the value zero to the
+Count register will stop the counter, thereby disabling the timer,
+independent of the setting of AutoEnable in the configuration register."
+so a timer with a 0 count should never be in the enabled state.
+
+This is XSA-504 / CVE-2026-62431.
+
+Fixes: 26fba3c85571 ("viridian: add implementation of synthetic timers")
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+diff --git a/xen/arch/x86/hvm/viridian/time.c b/xen/arch/x86/hvm/viridian/time.c
+index 3c94fb0814e9..0577707d1202 100644
+--- a/xen/arch/x86/hvm/viridian/time.c
++++ b/xen/arch/x86/hvm/viridian/time.c
+@@ -156,6 +156,14 @@ static void start_stimer(struct viridian_stimer *vs)
+         printk(XENLOG_G_INFO "%pv: VIRIDIAN STIMER%u: enabled\n", v,
+                stimerx);
+ 
++    if ( !vs->count )
++    {
++        gprintk(XENLOG_ERR, "VIRIDIAN STIMER started with 0 count\n");
++        ASSERT_UNREACHABLE();
++        domain_crash(v->domain);
++        return;
++    }
++
+     if ( vs->config.periodic )
+     {
+         /*
+@@ -365,7 +373,7 @@ int viridian_time_wrmsr(struct vcpu *v, uint32_t idx, uint64_t val)
+ 
+         vs->config.as_uint64 = val;
+ 
+-        if ( !vs->config.sintx )
++        if ( !vs->config.sintx || !vs->count )
+             vs->config.enable = 0;
+ 
+         if ( vs->config.enable )
+@@ -576,6 +584,9 @@ void viridian_time_load_vcpu_ctxt(
+ 
+         vs->config.as_uint64 = ctxt->stimer_config_msr[i];
+         vs->count = ctxt->stimer_count_msr[i];
++        if ( !vs->config.sintx || !vs->count )
++            /* Reject enabling with a zero sintx or count fields. */
++            vs->config.enable = 0;
+     }
+ }
+ 

--- a/SOURCES/xsa505.patch
+++ b/SOURCES/xsa505.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Tue, 21 Jul 2026 12:35:16 +0000
+Subject: [PATCH] xen/evtchn: fix race between FIFO expand and reset operations
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+evtchn_fifo_expand_array() will check for the domain evtchn_fifo being
+populated without holding the event_lock, which can lead to a race with a
+concurrent evtchn_reset().
+
+Ensure the checking for evtchn_fifo presence is done while holding the
+event_lock.
+
+This is XSA-505 / CVE-2026-62432.
+
+Fixes: 400b3bd6426f ("evtchn: make EVTCHNOP_reset suitable for kexec")
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+
+diff --git a/xen/common/event_fifo.c b/xen/common/event_fifo.c
+index 6cebc3868a07..ea613cfdcaf5 100644
+--- a/xen/common/event_fifo.c
++++ b/xen/common/event_fifo.c
+@@ -692,13 +692,11 @@ static int add_page_to_event_array(struct domain *d, unsigned long gfn)
+ int evtchn_fifo_expand_array(const struct evtchn_expand_array *expand_array)
+ {
+     struct domain *d = current->domain;
+-    int rc;
+-
+-    if ( !d->evtchn_fifo )
+-        return -EOPNOTSUPP;
++    int rc = -EOPNOTSUPP;
+ 
+     write_lock(&d->event_lock);
+-    rc = add_page_to_event_array(d, expand_array->array_gfn);
++    if ( d->evtchn_fifo )
++        rc = add_page_to_event_array(d, expand_array->array_gfn);
+     write_unlock(&d->event_lock);
+ 
+     return rc;

--- a/SOURCES/xsa507.patch
+++ b/SOURCES/xsa507.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Roger Pau Monne <roger.pau@citrix.com>
+Date: Tue, 14 Jul 2026 17:05:45 +0200
+Subject: [PATCH] x86/pod: do not reclaim special pages for PoD cache
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When doing PoD cache reclaim as part of a decrease reservation call, avoid
+reclaiming special pages for the PoD cache.  Otherwise such pages get moved
+from the domain ->xenpage_list to the ->page_list, while still being
+referenced in ->shared_info domain field.
+
+Prevent PoD cache from reclaiming special pages, as nothing good can come
+out of it.
+
+This is XSA-507 / CVE-2026-62434.
+
+Fixes: 41aa0b62699e ("PoD memory 4/9: Decrease reservation")
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+diff --git a/xen/arch/x86/mm/p2m-pod.c b/xen/arch/x86/mm/p2m-pod.c
+index e903db9d9367..380b69dba587 100644
+--- a/xen/arch/x86/mm/p2m-pod.c
++++ b/xen/arch/x86/mm/p2m-pod.c
+@@ -559,12 +559,13 @@ decrease_reservation(struct domain *d, gfn_t gfn, unsigned int order)
+         p2m_access_t a;
+         p2m_type_t t;
+         unsigned int cur_order;
++        mfn_t mfn = p2m->get_entry(p2m, gfn_add(gfn, i), &t, &a, 0, &cur_order,
++                                   NULL);
+ 
+-        p2m->get_entry(p2m, gfn_add(gfn, i), &t, &a, 0, &cur_order, NULL);
+         n = 1UL << min(order, cur_order);
+         if ( p2m_is_pod(t) )
+             pod += n;
+-        else if ( p2m_is_ram(t) )
++        else if ( p2m_is_ram(t) && !is_special_page(mfn_to_page(mfn)) )
+             ram += n;
+     }
+ 
+@@ -667,6 +668,9 @@ decrease_reservation(struct domain *d, gfn_t gfn, unsigned int order)
+             ASSERT(mfn_valid(mfn));
+ 
+             page = mfn_to_page(mfn);
++            if ( is_special_page(page) )
++                /* Do not touch special pages, let generic code handle them. */
++                continue;
+ 
+             /* This shouldn't be able to fail */
+             if ( p2m_set_entry(p2m, gfn_add(gfn, i), INVALID_MFN, cur_order,

--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -31,7 +31,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.6
-Release: %{?xsrel}.3%{?dist}
+Release: %{?xsrel}.3.1%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.6.tar.gz
@@ -343,6 +343,15 @@ Patch1023: dts-0004-x86-platform-Adjust-temperature-sensors-MSRs.patch
 Patch1024: dts-0005-libxc-Report-EINVAL-in-invalid-xc_resource_op-use.patch
 Patch1025: dts-0006-xenpm-Use-EXIT_-SUCCESS-FAILURE-instead-of-errno-as-.patch
 Patch1026: dts-0007-xenpm-Add-get-core-temp-subcommand.patch
+
+# XSA-497,500,501,503,504,505,507
+Patch1027: xsa497.patch
+Patch1028: xsa500.patch
+Patch1029: xsa501.patch
+Patch1030: xsa503.patch
+Patch1031: xsa504.patch
+Patch1032: xsa505.patch
+Patch1033: xsa507.patch
 
 ExclusiveArch: x86_64
 
@@ -1190,6 +1199,16 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Mon Jul 27 2026 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.17.6-9.3.1
+- Fix for XSA-497 (CVE-2026-42494, CVE-2026-42495, CVE-2026-62423,
+  CVE-2026-62424, CVE-2026-62425)
+- Fix for XSA-500 (CVE-2026-62428)
+- Fix for XSA-501
+- Fix for XSA-503 (CVE-2026-62430)
+- Fix for XSA-504 (CVE-2026-62431)
+- Fix for XSA-505 (CVE-2026-62432)
+- Fix for XSA-507 (CVE-2026-62434)
+
 * Thu Jun 11 2026 Teddy Astie <teddy.astie@vates.tech> - 4.17.6-9.3
 - Add support for Intel Digital Thermal Sensors.
 - Introduce xenpm get-core-temp command.


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3588

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

This is the first step of the sync with XS release 4.17.6-12.
We first sync with the fasttrack branch (release 4.17.6-9.3.1) containing the patches for XSAs 497 to 507, then we will open another PR for XS release 4.17.6-12 sync.

#### Release Target

- [ ] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [x] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

This is an intermediate release before the sync with the latest XS release 4.17.6-12. No build needed?

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

This release should not make it to the user but just in case we produce a build:
```
Integrate fast-tracked changes for XSAs 497, 500, 501, 503, 504, 505, and 507 into the main 8.3 release branch.
```

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

Only bug fixes.

<!-- Add links to the documentation update PRs if/when they are created. -->

N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Built, installation, boot, and pytest vm basic operations.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

XSA patches already tested through previous release 4.17.6-9.3.1

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Usual CI tests for regression tests

#### What tests have been or will be added to CI for this change? If none, explain why.

N/A

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
