### PR TITLE
Rebuild against OpenSSL 3.0

### DIFF
--- a/SPECS/xen.spec
+++ b/SPECS/xen.spec
@@ -31,7 +31,7 @@
 Summary: Xen is a virtual machine monitor
 Name:    xen
 Version: 4.17.6
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPLv2 and LGPLv2 and MIT and Public Domain
 URL:     https://www.xenproject.org
 Source0: xen-4.17.6.tar.gz
@@ -1211,6 +1211,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Tue Aug 04 2026 Gael Duperrey <gduperrey@vates.tech> - 4.17.6-9.12.2
+- Rebuild against OpenSSL 3.0
+
 * Thu Jul 30 2026 Thierry Escande <thierry.escande@vates.tech> - 4.17.6-9.12.1
 - Sync with v8.3-fasttrack-2026-07-27 branch
 - *** Fasttrack branch changelog ***


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3588

#### Related changes (optional)

#100 

OpenSSL 3.5 was updated but it has to be reverted (it was breaking OpenSSH rebuild)

Related-to: XCPNG-3597
Related-to: XCPNG-3273

#### Context & Motivation

OpenSSL 3.5 was updated but it has to be reverted (it was breaking OpenSSH rebuild)

#### Release Target

[x] milestone defined : 8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

Not needed (rely on previous change)

#### Attention points

none: maybe openssh will be fixed later tbc

#### Documentation update needed

- [x] No

---

### Testing and regression avoidance

#### What tests have you performed?

Refer to info in related PR
none relying on ci

#### What manual tests should be performed after the build, and by whom?

Refer to info in related PR
none relying on ci

#### What's covered by the xcp-ng-tests test suite?

Refer to info in related PR
none relying on ci

#### What tests have been or will be added to CI for this change? If none, explain why.

Refer to info in related PR
none relying on ci

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

